### PR TITLE
feat(landing-page): Integrate PostHog analytics into landing page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.biome": "explicit"
+    "source.fixAll.biome": "never"
   },
   "editor.defaultFormatter": "biomejs.biome",
   "editor.formatOnSave": true

--- a/apps/landing-page/src/components/posthog.astro
+++ b/apps/landing-page/src/components/posthog.astro
@@ -1,0 +1,10 @@
+---
+// src/components/posthog.astro
+---
+<script is:inline>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('phc_KVPKLlfKKnWzmyqkFDReuDsh7CeoyXeJO7mJ0zcCVV8', {
+      api_host:'https://us.i.posthog.com',
+      defaults: '2025-05-24'
+    })
+</script>

--- a/apps/landing-page/src/layouts/PostHogLayout.astro
+++ b/apps/landing-page/src/layouts/PostHogLayout.astro
@@ -1,0 +1,6 @@
+---
+import PostHog from "../components/posthog.astro";
+---
+<head>
+    <PostHog />
+</head>

--- a/apps/landing-page/src/pages/index.astro
+++ b/apps/landing-page/src/pages/index.astro
@@ -9,15 +9,19 @@ import CTA from "../sections/CTA.astro";
 import Layout from "../layouts/Landing.astro";
 import Navbar from "../sections/Navbar.astro";
 import Footer from "../sections/Footer.astro";
+import PostHogLayout from "../layouts/PostHogLayout.astro";
 ---
-<Layout>
-  <Navbar />
-  <Hero />
-  <TrustSection />
-  <Features />
-  <HowItWorks />
-  <UseCasesSection />
-  <FAQ/>
-  <CTA/>
-  <Footer />
-</Layout>
+<PostHogLayout>
+  <Layout>
+    <Navbar />
+    <Hero />
+    <TrustSection />
+    <Features />
+    <HowItWorks />
+    <UseCasesSection />
+    <FAQ/>
+    <CTA/>
+    <Footer />
+  </Layout>
+</PostHogLayout>
+


### PR DESCRIPTION
This pull request makes significant changes to the landing page application by removing multiple components and introducing a new `StarRating` component. The deletions simplify the codebase by removing unused or redundant sections, while the addition of `StarRating` provides a reusable component for displaying star ratings.

### Component Removals:
* Removed the `CTABlock.astro` component, which contained a call-to-action section for starting a trial or booking a demo.
* Removed the `Features.astro` component, which showcased features of the blog automation SaaS.
* Removed the `Footer.astro` component, which included branding, quick links, and resources.
* Removed the `Hero.astro` component, which served as the main hero section with a call-to-action button and placeholder for a dashboard preview.
* Removed the `HowItWorks.astro` component, which outlined a step-by-step onboarding flow.
* Removed the `Navbar.astro` component, which implemented a floating navigation bar with scroll-based visibility.
* Removed the `SocialProof.astro` component, which displayed testimonials and logos for social proof.
* Removed the `GetStarted.astro` component, which provided steps to set up the EAR stack.

### New Component Addition:
* Added a `StarRating.astro` component that renders a customizable number of star icons with a default count of 5. This component can be styled using the `size` prop for flexibility.

### Configuration Updates:
* Updated `.vscode/settings.json` to change the `editor.codeActionsOnSave` setting for `biome` from `"explicit"` to `"never"`. This prevents automatic fixes from being applied on save.