### PR TITLE
Update content stats when saving content changes

### DIFF
--- a/packages/api/src/server/router/content.ts
+++ b/packages/api/src/server/router/content.ts
@@ -382,10 +382,12 @@ export const contentRouter = router({
             // Calculate new stats for the updated content
             const newStats = calculateContentStats(input.body);
 
-            // Preserve existing qualityScore if present, or set to current content's qualityScore
+            // Merge existing stats with new stats, preserving existing values unless new ones should override
             const updatedStats = {
+               ...currentContent.stats,
                ...newStats,
-               qualityScore: currentContent.stats?.qualityScore || undefined,
+               qualityScore:
+                  currentContent.stats?.qualityScore ?? newStats.qualityScore,
             };
 
             // Update the content

--- a/packages/helpers/src/text.ts
+++ b/packages/helpers/src/text.ts
@@ -1,4 +1,5 @@
 import slugfy from "slugify";
+import type { ContentStats } from "@packages/database/schemas/content";
 export type Diff = [number, string][];
 export type LineDiff = {
    type: "add" | "remove" | "context" | "modify";
@@ -292,7 +293,7 @@ export function formatValueForDisplay(value: string) {
    return value.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-export function calculateContentStats(content: string) {
+export function calculateContentStats(content: string): ContentStats {
    const wordCount = countWords(content);
    const readTime = readTimeMinutes(wordCount);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Content stats (word count and estimated read time) now update automatically whenever you edit a content’s body.
  * Existing quality score is preserved while other stats refresh, maintaining prior assessments.
  * Stats shown on detail pages and listings stay accurate after edits with no extra steps required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->