### PR TITLE
feat(dashboard): Add collapsible sub-menus to sidebar navigation

### DIFF
--- a/apps/dashboard/src/layout/app-sidebar.tsx
+++ b/apps/dashboard/src/layout/app-sidebar.tsx
@@ -15,16 +15,23 @@ import {
    LayoutDashboardIcon,
    Lightbulb,
    Target,
+   FileText,
 } from "lucide-react";
 import type * as React from "react";
+import { Link } from "@tanstack/react-router";
 import { NavMain } from "./nav-main";
 import { NavUser } from "./nav-user";
 import type { Session } from "@/integrations/clients";
 
 type NavigationItems = {
-   url: keyof FileRoutesByTo;
+   url?: keyof FileRoutesByTo;
    title: string;
    icon: typeof LayoutDashboardIcon;
+   subItems?: {
+      url: keyof FileRoutesByTo;
+      title: string;
+      icon?: typeof LayoutDashboardIcon;
+   }[];
 };
 
 export function AppSidebar({
@@ -33,24 +40,25 @@ export function AppSidebar({
 }: React.ComponentProps<typeof Sidebar> & { session: Session | null }) {
    const navMain: NavigationItems[] = [
       {
-         icon: LayoutDashboardIcon,
-         title: "Dashboard",
-         url: "/home",
-      },
-      {
-         icon: Bot,
-         title: "Your Agents",
-         url: "/agents",
-      },
-      {
          icon: FilesIcon,
-         title: "Your Content",
-         url: "/content",
-      },
-      {
-         icon: Lightbulb,
-         title: "Your Ideas",
-         url: "/ideas",
+         title: "Content",
+         subItems: [
+            {
+               url: "/agents",
+               title: "Content Agents",
+               icon: Bot,
+            },
+            {
+               url: "/ideas",
+               title: "Content Ideas",
+               icon: Lightbulb,
+            },
+            {
+               url: "/content",
+               title: "Created Content",
+               icon: FileText,
+            },
+         ],
       },
       {
          icon: Target,
@@ -64,7 +72,7 @@ export function AppSidebar({
          <SidebarHeader>
             <SidebarMenu>
                <SidebarMenuItem>
-                  <div className="flex items-center gap-2">
+                  <Link to="/home" className="flex items-center gap-2">
                      <figure className="text-primary">
                         <img
                            alt="Project logo"
@@ -76,7 +84,7 @@ export function AppSidebar({
                      <span className="text-lg font-semibold">
                         {brandConfig.name}
                      </span>
-                  </div>
+                  </Link>
                </SidebarMenuItem>
             </SidebarMenu>
          </SidebarHeader>

--- a/apps/dashboard/src/layout/nav-main.tsx
+++ b/apps/dashboard/src/layout/nav-main.tsx
@@ -4,23 +4,38 @@ import {
    SidebarMenu,
    SidebarMenuButton,
    SidebarMenuItem,
+   SidebarMenuSub,
+   SidebarMenuSubItem,
+   SidebarMenuSubButton,
    useSidebar,
 } from "@packages/ui/components/sidebar";
 import { Link, useLocation } from "@tanstack/react-router";
 import type { LucideIcon } from "lucide-react";
+import { ChevronDown } from "lucide-react";
+import {
+   Collapsible,
+   CollapsibleTrigger,
+   CollapsibleContent,
+} from "@packages/ui/components/collapsible";
 
 export function NavMain({
    items,
 }: {
    items: {
       title: string;
-      url: string;
+      url?: string;
       icon?: LucideIcon;
+      subItems?: {
+         url: string;
+         title: string;
+         icon?: LucideIcon;
+      }[];
    }[];
 }) {
    const { pathname } = useLocation();
    const { setOpenMobile } = useSidebar();
    const isActive = (url: string) => {
+      if (!url) return false;
       return pathname.startsWith(url);
    };
 
@@ -28,25 +43,86 @@ export function NavMain({
       <SidebarGroup>
          <SidebarGroupContent className="flex flex-col gap-2">
             <SidebarMenu>
-               {items.map((item) => (
-                  <SidebarMenuItem
-                     className={`${isActive(item.url) ? "bg-primary/10 text-primary rounded-lg" : ""}`}
-                     key={item.title}
-                  >
-                     <SidebarMenuButton asChild tooltip={item.title}>
-                        <Link
-                           className="flex items-center gap-2"
-                           to={item.url}
-                           onClick={() => setOpenMobile(false)}
+               {items.map((item) => {
+                  if (item.subItems) {
+                     return (
+                        <Collapsible
+                           key={item.title}
+                           defaultOpen={isActive(item.url || "")}
                         >
-                           {item.icon && <item.icon />}
-                           <span>{item.title}</span>
-                        </Link>
-                     </SidebarMenuButton>
-                  </SidebarMenuItem>
-               ))}
+                           <SidebarMenuItem>
+                              <CollapsibleTrigger asChild>
+                                 <SidebarMenuButton
+                                    asChild
+                                    tooltip={item.title}
+                                    className={`${isActive(item.url || "") ? "bg-primary/10 text-primary rounded-lg" : ""}`}
+                                 >
+                                    <div className="flex items-center justify-between w-full">
+                                       <Link
+                                          className="flex items-center gap-2"
+                                          to={item.url || ""}
+                                          onClick={() => setOpenMobile(false)}
+                                       >
+                                          {item.icon && (
+                                             <item.icon className="h-4 w-4" />
+                                          )}
+                                          <span>{item.title}</span>
+                                       </Link>
+                                       <ChevronDown className="h-4 w-4 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-180" />
+                                    </div>
+                                 </SidebarMenuButton>
+                              </CollapsibleTrigger>
+                              <CollapsibleContent>
+                                 <SidebarMenuSub>
+                                    {item.subItems.map((subItem) => (
+                                       <SidebarMenuSubItem key={subItem.title}>
+                                          <SidebarMenuSubButton
+                                             asChild
+                                             className={`${isActive(subItem.url) ? "bg-primary/10 text-primary rounded-lg" : ""}`}
+                                          >
+                                             <Link
+                                                className="flex items-center gap-2"
+                                                to={subItem.url}
+                                                onClick={() =>
+                                                   setOpenMobile(false)
+                                                }
+                                             >
+                                                {subItem.icon && (
+                                                   <subItem.icon />
+                                                )}
+                                                <span>{subItem.title}</span>
+                                             </Link>
+                                          </SidebarMenuSubButton>
+                                       </SidebarMenuSubItem>
+                                    ))}
+                                 </SidebarMenuSub>
+                              </CollapsibleContent>
+                           </SidebarMenuItem>
+                        </Collapsible>
+                     );
+                  }
+
+                  return (
+                     <SidebarMenuItem
+                        className={`${isActive(item.url || "") ? "bg-primary/10 text-primary rounded-lg" : ""}`}
+                        key={item.title}
+                     >
+                        <SidebarMenuButton asChild tooltip={item.title}>
+                           <Link
+                              className="flex items-center gap-2"
+                              to={item.url || ""}
+                              onClick={() => setOpenMobile(false)}
+                           >
+                              {item.icon && <item.icon />}
+                              <span>{item.title}</span>
+                           </Link>
+                        </SidebarMenuButton>
+                     </SidebarMenuItem>
+                  );
+               })}
             </SidebarMenu>
          </SidebarGroupContent>
       </SidebarGroup>
    );
 }
+

--- a/apps/dashboard/src/pages/competitor-list/ui/competitor-card.tsx
+++ b/apps/dashboard/src/pages/competitor-list/ui/competitor-card.tsx
@@ -83,7 +83,7 @@ export function CompetitorCard({ competitor }: CompetitorCardProps) {
                         {formatDate(new Date(competitor.createdAt))}
                      </Badge>
                      {competitor.features && competitor.features.length > 0 && (
-                        <Badge variant="secondary" className="text-xs">
+                        <Badge className="text-xs">
                            {competitor.features.length} features
                         </Badge>
                      )}

--- a/apps/dashboard/src/pages/competitor-list/ui/competitor-list-page.tsx
+++ b/apps/dashboard/src/pages/competitor-list/ui/competitor-list-page.tsx
@@ -10,7 +10,7 @@ import { CompetitorListProvider } from "../lib/competitor-list-context";
 
 function CompetitorListPageContent() {
    return (
-      <main className="h-full w-full flex flex-col gap-4 p-4">
+      <main className="h-full w-full flex flex-col gap-4">
          <TalkingMascot message="Track and analyze your competitors to stay ahead of the market!" />
          <CompetitorListToolbar />
          <Suspense fallback={<CompetitorCardsSkeleton />}>

--- a/apps/dashboard/src/pages/content-list/ui/content-list-page.tsx
+++ b/apps/dashboard/src/pages/content-list/ui/content-list-page.tsx
@@ -39,7 +39,7 @@ function ContentListPageContent() {
    );
 
    return (
-      <main className="h-full w-full flex flex-col gap-4 p-4">
+      <main className="h-full w-full flex flex-col gap-4">
          <TalkingMascot message="Here you can manage all your content, Create, Delete, or explore it below!" />
          <ContentListToolbar />
          <Suspense fallback={<ContentCardsSkeleton />}>

--- a/bun.lock
+++ b/bun.lock
@@ -400,6 +400,7 @@
         "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-checkbox": "^1.3.2",
+        "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-label": "^2.0.2",

--- a/packages/api/src/server/router/competitor.ts
+++ b/packages/api/src/server/router/competitor.ts
@@ -19,6 +19,7 @@ import { NotFoundError, DatabaseError } from "@packages/errors";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { enqueueCompetitorCrawlJob } from "@packages/workers/queues/competitors/competitor-crawl-queue";
+import { deleteFeaturesByCompetitorId } from "@packages/database/repositories/competitor-feature-repository";
 
 export const competitorRouter = router({
    list: protectedProcedure
@@ -257,6 +258,9 @@ export const competitorRouter = router({
                      "You don't have permission to analyze this competitor.",
                });
             }
+
+            // Delete existing competitor features before starting fresh analysis
+            await deleteFeaturesByCompetitorId(resolvedCtx.db, competitor.id);
 
             // Enqueue competitor analysis job
             await enqueueCompetitorCrawlJob({

--- a/packages/database/src/repositories/competitor-feature-repository.ts
+++ b/packages/database/src/repositories/competitor-feature-repository.ts
@@ -314,6 +314,24 @@ export async function bulkDeleteFeatures(
    }
 }
 
+export async function deleteFeaturesByCompetitorId(
+   dbClient: DatabaseInstance,
+   competitorId: string,
+): Promise<{ deletedCount: number }> {
+   try {
+      const result = await dbClient
+         .delete(competitorFeature)
+         .where(eq(competitorFeature.competitorId, competitorId))
+         .returning();
+
+      return { deletedCount: result.length };
+   } catch (err) {
+      throw new DatabaseError(
+         `Failed to delete competitor features by competitor ID: ${(err as Error).message}`,
+      );
+   }
+}
+
 export async function getFeaturesStats(
    dbClient: DatabaseInstance,
    {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,7 @@
       "@radix-ui/react-alert-dialog": "^1.1.14",
       "@radix-ui/react-avatar": "^1.1.10",
       "@radix-ui/react-checkbox": "^1.3.2",
+      "@radix-ui/react-collapsible": "^1.1.12",
       "@radix-ui/react-dialog": "^1.1.14",
       "@radix-ui/react-dropdown-menu": "^2.1.15",
       "@radix-ui/react-label": "^2.0.2",

--- a/packages/ui/src/components/collapsible.tsx
+++ b/packages/ui/src/components/collapsible.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  )
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      {...props}
+    />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Sidebar revamped: single “Content” section with collapsible submenus for Content Agents, Content Ideas, and Created Content.
  - Clickable header logo now links to Home.

- UI/Style
  - Reduced page padding on Competitor List and Content List pages for a cleaner layout.
  - Updated features badge style on competitor cards.

- Bug Fixes
  - Competitor analysis now clears old features before re-running, ensuring fresh results.

- Chores
  - Added collapsible UI dependency and components to support expandable navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->