### PR TITLE
fix(web): Eagerly import prismjs to resolve lexical issue

### DIFF
--- a/apps/web/src/layout/editor/ui/editor-standalone-layout.tsx
+++ b/apps/web/src/layout/editor/ui/editor-standalone-layout.tsx
@@ -3,6 +3,12 @@
  * Container principal sem sidebar do dashboard.
  * Gerencia keybinds globais sem conflitos com o browser.
  */
+// Must be imported eagerly before the lazy editor chunk loads.
+// @lexical/code's prism language plugins reference `Prism` as a global variable.
+// This ensures window.Prism is set before ClientOnly evaluates those plugins.
+// See: https://github.com/facebook/lexical/issues/6575
+import "prismjs";
+
 import type { ReactNode } from "react";
 
 interface EditorStandaloneLayoutProps {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -14,7 +14,7 @@ const config = defineConfig({
       },
    },
    optimizeDeps: {
-      include: ["react", "react-dom"],
+      include: ["react", "react-dom", "prismjs"],
    },
    plugins: [
       devtools(),


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a runtime issue where Lexical's code plugin couldn't find the `Prism` global variable by eagerly importing prismjs before lazy chunks load.

- Added `import "prismjs"` at the top of `editor-standalone-layout.tsx` with clear documentation explaining the fix
- Added `prismjs` to Vite's `optimizeDeps.include` to pre-bundle the dependency
- References upstream Lexical issue #6575 for context

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks
- The fix is well-documented, follows best practices for resolving global variable dependencies in code-split applications, and references the upstream issue. Both changes are minimal and targeted.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/layout/editor/ui/editor-standalone-layout.tsx | Added eager prismjs import with clear documentation to fix lexical code plugin global variable issue |
| apps/web/vite.config.ts | Added prismjs to Vite optimizeDeps to pre-bundle dependency for better performance |

</details>


</details>


<sub>Last reviewed commit: b051869</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->