### PR TITLE
style(ui): Add styles to calendar component

### DIFF
--- a/packages/ui/src/components/date-range-picker.tsx
+++ b/packages/ui/src/components/date-range-picker.tsx
@@ -135,6 +135,10 @@ export function DateRangePicker({
          <div className="p-2">
             <Calendar
                captionLayout="dropdown"
+               classNames={{
+                  months: "flex gap-0 flex-col md:flex-row relative",
+                  month: "p-2 [&:not(:first-child)]:border-l",
+               }}
                components={{ Dropdown: CalendarDropdown }}
                fromYear={2020}
                mode="range"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `classNames` overrides to the `Calendar` component within `DateRangePicker` to style the dual-month calendar layout — removing the gap between months (`gap-0` instead of `gap-4`) and adding a left border separator between them.

- The `classNames` prop uses an object spread in `Calendar` (`...classNames`), which **fully replaces** the default computed class strings rather than merging with them. This causes the `month` override to drop essential layout classes (`flex flex-col w-full gap-4`) and react-day-picker's own `defaultClassNames`, which may break month panel rendering.
- The `months` override similarly drops `defaultClassNames.months` from react-day-picker, though the custom classes largely replicate the needed flex layout.

<h3>Confidence Score: 3/5</h3>

- Low-risk styling change but the month classNames override likely drops essential layout classes, which may cause visual breakage.
- The change is small and scoped to styling only, but the `month` classNames override fully replaces the Calendar's default flex layout classes and react-day-picker defaults, which will likely cause the month panels to render incorrectly (days/weeks not stacking vertically).
- `packages/ui/src/components/date-range-picker.tsx` — verify the `month` classNames override preserves necessary base layout classes.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/ui/src/components/date-range-picker.tsx | Adds `classNames` overrides to Calendar for tighter month spacing and a left border separator, but the override mechanism fully replaces Calendar defaults including react-day-picker base classes, likely breaking month panel layout. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DateRangePicker] -->|classNames prop| B[Calendar Component]
    B -->|spreads ...classNames| C[DayPicker / react-day-picker]
    
    subgraph "classNames Override Flow"
        D["Calendar defaults:<br/>months: cn('flex gap-4 ...', defaultClassNames.months)<br/>month: cn('flex flex-col w-full gap-4', defaultClassNames.month)"]
        E["DateRangePicker overrides:<br/>months: 'flex gap-0 flex-col md:flex-row relative'<br/>month: 'p-2 [&:not(:first-child)]:border-l'"]
        F["Result: Overrides fully replace defaults<br/>(month loses flex layout + defaultClassNames)"]
    end
    
    D --> F
    E --> F
```

<sub>Last reviewed commit: fcabb83</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=f21f88c3-b358-41b2-80aa-33a5bbac1bc3))

<!-- /greptile_comment -->