### PR TITLE
feat(billing): integrate early access feature stage badge and filter …

### DIFF
--- a/apps/web/src/features/billing/ui/billing-overview.tsx
+++ b/apps/web/src/features/billing/ui/billing-overview.tsx
@@ -26,6 +26,7 @@ import {
 } from "@packages/ui/components/empty";
 import { Progress } from "@packages/ui/components/progress";
 import { Skeleton } from "@packages/ui/components/skeleton";
+import { FeatureStageBadge } from "@packages/ui/components/feature-stage-badge";
 import {
    Tooltip,
    TooltipContent,
@@ -56,6 +57,7 @@ import type { ReactNode } from "react";
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useActiveOrganization } from "@/hooks/use-active-organization";
+import { useEarlyAccess } from "@/hooks/use-early-access";
 import { orpc } from "@/integrations/orpc/client";
 
 // ============================================
@@ -119,6 +121,8 @@ const CATEGORY_CONFIG: Record<
       icon: <Webhook className="size-5" />,
    },
 };
+
+const BETA_CATEGORY_FLAGS: Record<string, string> = { form: "forms-beta" };
 
 // ============================================
 // Helpers
@@ -345,7 +349,13 @@ function OverviewProductSubItems({ category }: { category: string }) {
    );
 }
 
-function OverviewProductCard({ category }: { category: CategorySummary }) {
+function OverviewProductCard({
+   category,
+   isBeta,
+}: {
+   category: CategorySummary;
+   isBeta?: boolean;
+}) {
    const config = CATEGORY_CONFIG[category.category];
    if (!config) return null;
 
@@ -367,6 +377,7 @@ function OverviewProductCard({ category }: { category: CategorySummary }) {
                         </CardDescription>
                      </div>
                   </div>
+                  {isBeta && <FeatureStageBadge stage="beta" />}
                </div>
             </CardHeader>
 
@@ -636,6 +647,7 @@ export function BillingOverview() {
       orpc.billing.getCurrentUsage.queryOptions({}),
    );
    const { activeSubscription } = useActiveOrganization();
+   const { isEnrolled } = useEarlyAccess();
 
    const planName = activeSubscription
       ? (activeSubscription.plan as string).toLowerCase()
@@ -643,8 +655,11 @@ export function BillingOverview() {
 
    const plan = STRIPE_PLANS.find((p) => p.name.toLowerCase() === planName);
 
-   // All known categories that should always be displayed
-   const ALL_CATEGORIES = Object.keys(CATEGORY_CONFIG);
+   const ALL_CATEGORIES = Object.keys(CATEGORY_CONFIG).filter((cat) => {
+      const flag = BETA_CATEGORY_FLAGS[cat];
+      if (!flag) return true;
+      return isEnrolled(flag);
+   });
 
    // Merge API data with known categories — always show all cards
    const categoryDataMap = new Map(data.byCategory.map((c) => [c.category, c]));
@@ -711,7 +726,11 @@ export function BillingOverview() {
             <h2 className="text-lg font-semibold mb-4">Produtos</h2>
             <div className="space-y-4">
                {sortedCategories.map((cat) => (
-                  <OverviewProductCard category={cat} key={cat.category} />
+                  <OverviewProductCard
+                     category={cat}
+                     isBeta={BETA_CATEGORY_FLAGS[cat.category] !== undefined}
+                     key={cat.category}
+                  />
                ))}
             </div>
          </div>


### PR DESCRIPTION
…beta categories in billing overview

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added early access feature stage badges to beta categories in the billing overview and implemented filtering to hide beta categories when users aren't enrolled in their corresponding early access flags.

- Imported `FeatureStageBadge` component and `useEarlyAccess` hook
- Created `BETA_CATEGORY_FLAGS` mapping to track which categories require early access enrollment
- Modified `OverviewProductCard` to accept and display an optional beta badge
- Filtered `ALL_CATEGORIES` to exclude beta categories when user is not enrolled in the corresponding flag
- Applied beta badge to form category using the flag `forms-beta`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-isolated, follow existing patterns used elsewhere in the codebase (matching the `earlyAccessFlag` pattern in sidebar navigation), use proper type safety, and integrate cleanly with the existing early access system. The implementation correctly filters categories and displays badges without modifying core logic or data flows.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/features/billing/ui/billing-overview.tsx | Added early access feature stage badge to beta categories and filter out non-enrolled beta categories from billing overview |

</details>


</details>


<sub>Last reviewed commit: d044b33</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->