### PR TITLE
Enhance organization operations documentation and update member data …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,9 +322,12 @@ organization({
 
 Field types: `"string"` (TEXT), `"boolean"` (BOOLEAN), `"number"` (INTEGER), `"string[]"` (TEXT[]), `"json"` (JSONB + Zod validator)
 
-**Organization operations** use the Better Auth client directly — do NOT wrap in oRPC procedures:
+**Query/Mutation split for Better Auth**
+- **Queries** (read operations) → always use oRPC (`orpc.organization.*`), even for Better Auth-owned data like members, teams, and invitations. oRPC procedures enrich the raw Better Auth data with DB fields (plans, credits, slugs, etc.) that the raw client cannot provide.
+- **Mutations** (write operations) → use `authClient` directly. Never wrap these in oRPC.
+
 ```typescript
-// Client-side (apps/web) — use authClient.organization.*
+// ✅ Mutations — authClient only
 authClient.organization.create({ name, slug })
 authClient.organization.update({ data: { name }, organizationId })
 authClient.organization.delete({ organizationId })
@@ -332,13 +335,22 @@ authClient.organization.inviteMember({ email, role, organizationId })
 authClient.organization.removeMember({ memberIdOrEmail, organizationId })
 authClient.organization.updateMemberRole({ memberId, role, organizationId })
 authClient.organization.cancelInvitation({ invitationId })
-authClient.organization.getInvitation({ id })
 authClient.organization.setActive({ organizationId })
 authClient.organization.createTeam({ name, organizationId })
 authClient.organization.setActiveTeam({ teamId })
+
+// ✅ Queries — always oRPC (even for Better Auth data)
+orpc.organization.getMembers.queryOptions({})
+orpc.organization.getOrganizationTeams.queryOptions({})
+orpc.organization.getActiveOrganization.queryOptions({})
+orpc.organization.getMemberTeams.queryOptions({ input: { userId } })
 ```
 
-Read-only org data (members list, active org with subscription) uses oRPC (`orpc.organization.*`) since those enrich with DB data (plans, credits, etc.).
+**member.id vs user.id**
+`member.id` (member record ID, PK of the member table) and `user.id` (user UUID) are different values and must never be used interchangeably.
+- Use `member.id` for Better Auth mutation APIs (`removeMember`, `updateMemberRole`).
+- Use `member.userId` for queries against user-keyed tables (`teamMember.userId`, isSelf checks).
+- `getMembers` must expose both: `id` (member record ID) and `userId` (user ID).
 
 **Client-side authClient usage rules:**
 - **NEVER** wrap `authClient` calls inside `useMutation` — call them directly

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
    "private": true,
    "type": "module",
    "scripts": {
-      "container-start": "podman-compose down && podman-compose up -d",
+      "container-start": "docker-compose down && docker-compose up -d",
       "dev": "bun run container-start && bun --bun vite dev --port 3000",
       "build": "vite build",
       "start": "bun run .output/server/index.mjs",

--- a/apps/web/src/integrations/orpc/router/organization.ts
+++ b/apps/web/src/integrations/orpc/router/organization.ts
@@ -200,6 +200,7 @@ export const getMembers = protectedProcedure.handler(async ({ context }) => {
 
    return members.map((m) => ({
       id: m.id,
+      userId: m.userId,
       name: m.user.name,
       email: m.user.email,
       role: m.role,

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/members.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/members.tsx
@@ -80,6 +80,7 @@ export const Route = createFileRoute(
 
 type MemberRow = {
    id: string;
+   userId: string;
    name: string;
    email: string;
    role: string;
@@ -335,7 +336,7 @@ function MemberExpandedRow({ member }: { member: MemberRow }) {
    // Get teams this member has access to
    const { data: memberTeams, isLoading } = useQuery(
       orpc.organization.getMemberTeams.queryOptions({
-         input: { userId: member.id },
+         input: { userId: member.userId },
       }),
    );
 
@@ -408,7 +409,7 @@ function MemberMobileCard({
    );
    const currentUserId = sessionData?.user?.id;
    const member = row.original;
-   const isSelf = member.id === currentUserId;
+   const isSelf = member.userId === currentUserId;
 
    return (
       <Card>
@@ -757,7 +758,7 @@ function MembersContent() {
             header: "",
             cell: ({ row }) => {
                const member = row.original;
-               const isSelf = member.id === currentUserId;
+               const isSelf = member.userId === currentUserId;
                const isOwner = member.role === "owner";
                const isDisabled = isSelf || isOwner;
 


### PR DESCRIPTION
…handling

- Clarified the usage of oRPC for queries and direct authClient for mutations in Better Auth operations.
- Updated `getMembers` to include `userId` alongside `id` for better data handling.
- Adjusted member-related logic in the UI to utilize `userId` for consistency in member identification.
- Changed Docker command in package.json for container management.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed critical bug where `member.id` (member record ID) was incorrectly used instead of `member.userId` (user UUID) for identity checks and queries in the organization members UI.

- Added `userId` field to `getMembers` oRPC response to expose user ID alongside member record ID
- Updated `getMemberTeams` query to use `userId` instead of `id`
- Fixed `isSelf` checks to compare `userId` with current user ID
- Enhanced CLAUDE.md documentation to clarify the distinction between `member.id` and `user.id` and the query/mutation split pattern for Better Auth operations
- Changed Docker command from `podman-compose` to `docker-compose`

<h3>Confidence Score: 5/5</h3>

- Safe to merge - fixes a critical bug with proper implementation and comprehensive documentation
- The PR correctly addresses a data handling bug where member record IDs were being used interchangeably with user IDs. The fix is complete across both backend (oRPC router) and frontend (UI components), with corresponding documentation updates to prevent future confusion. No logic errors, syntax issues, or potential regressions identified.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CLAUDE.md | Enhanced documentation to clarify the query/mutation split pattern for Better Auth operations and the distinction between `member.id` and `user.id` |
| apps/web/package.json | Changed container command from `podman-compose` to `docker-compose` for broader compatibility |
| apps/web/src/integrations/orpc/router/organization.ts | Added `userId` field to `getMembers` response to properly expose user ID alongside member record ID |
| apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/members.tsx | Updated member-related logic to use `userId` instead of `id` for user identity checks and queries, fixing incorrect usage of member record ID |

</details>


</details>


<sub>Last reviewed commit: 19b2f14</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=f21f88c3-b358-41b2-80aa-33a5bbac1bc3))

<!-- /greptile_comment -->