### PR TITLE
740 layout padronização global do sistema de layout contextpanel subsidebar mainsidebar e internalsidebar

### DIFF
--- a/apps/web/src/features/clusters/ui/cluster-builder.tsx
+++ b/apps/web/src/features/clusters/ui/cluster-builder.tsx
@@ -17,9 +17,12 @@ import {
 } from "@tanstack/react-query";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import {
+   Activity,
    BookOpen,
    ExternalLink,
+   Layers,
    Loader2,
+   Network,
    Plus,
    Sparkles,
    Trash2,
@@ -522,14 +525,17 @@ function ClusterBuilderEdit({ clusterId }: ClusterBuilderEditProps) {
          </ContextPanelHeader>
          <ContextPanelContent>
             <ContextPanelMeta
+               icon={Layers}
                label="Modo"
                value={MODE_LABELS[mode] ?? mode}
             />
             <ContextPanelMeta
+               icon={Activity}
                label="Status"
                value={STATUS_LABELS[cluster.status] ?? cluster.status}
             />
             <ContextPanelMeta
+               icon={Network}
                label="Satélites"
                value={satellites.length}
             />

--- a/apps/web/src/features/clusters/ui/cluster-builder.tsx
+++ b/apps/web/src/features/clusters/ui/cluster-builder.tsx
@@ -1,6 +1,12 @@
 import { Badge } from "@packages/ui/components/badge";
 import { Button } from "@packages/ui/components/button";
 import { Card, CardContent } from "@packages/ui/components/card";
+import {
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelHeader,
+   ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
 import { Label } from "@packages/ui/components/label";
 import { Separator } from "@packages/ui/components/separator";
 import {
@@ -30,12 +36,6 @@ import {
 } from "lucide-react";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
-import {
-   ContextPanel,
-   ContextPanelContent,
-   ContextPanelHeader,
-   ContextPanelTitle,
-} from "@packages/ui/components/context-panel";
 import {
    ContextPanelAction,
    ContextPanelDivider,
@@ -521,7 +521,9 @@ function ClusterBuilderEdit({ clusterId }: ClusterBuilderEditProps) {
    useContextPanelInfo(
       <ContextPanel>
          <ContextPanelHeader>
-            <ContextPanelTitle>{pillarTitle || cluster.meta.title}</ContextPanelTitle>
+            <ContextPanelTitle>
+               {pillarTitle || cluster.meta.title}
+            </ContextPanelTitle>
          </ContextPanelHeader>
          <ContextPanelContent>
             <ContextPanelMeta

--- a/apps/web/src/features/clusters/ui/cluster-builder.tsx
+++ b/apps/web/src/features/clusters/ui/cluster-builder.tsx
@@ -22,10 +22,23 @@ import {
    Loader2,
    Plus,
    Sparkles,
+   Trash2,
    X,
 } from "lucide-react";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
+import {
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelHeader,
+   ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
+import {
+   ContextPanelAction,
+   ContextPanelDivider,
+   ContextPanelMeta,
+} from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { useSheet } from "@/hooks/use-sheet";
 import { orpc } from "@/integrations/orpc/client";
@@ -350,6 +363,17 @@ function SatellitesTab({
 
 // ─── Cluster Builder (Edit Mode) ─────────────────────────────────────────────
 
+const MODE_LABELS: Record<string, string> = {
+   seo: "SEO",
+   changelog: "Changelog",
+   series: "Série",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+   draft: "Rascunho",
+   published: "Publicado",
+};
+
 interface ClusterBuilderEditProps {
    clusterId: string;
 }
@@ -489,6 +513,35 @@ function ClusterBuilderEdit({ clusterId }: ClusterBuilderEditProps) {
          setMode(data.mode);
       },
       [],
+   );
+
+   useContextPanelInfo(
+      <ContextPanel>
+         <ContextPanelHeader>
+            <ContextPanelTitle>{pillarTitle || cluster.meta.title}</ContextPanelTitle>
+         </ContextPanelHeader>
+         <ContextPanelContent>
+            <ContextPanelMeta
+               label="Modo"
+               value={MODE_LABELS[mode] ?? mode}
+            />
+            <ContextPanelMeta
+               label="Status"
+               value={STATUS_LABELS[cluster.status] ?? cluster.status}
+            />
+            <ContextPanelMeta
+               label="Satélites"
+               value={satellites.length}
+            />
+            <ContextPanelDivider />
+            <ContextPanelAction
+               icon={Trash2}
+               label="Deletar cluster"
+               onClick={handleDelete}
+               variant="destructive"
+            />
+         </ContextPanelContent>
+      </ContextPanel>,
    );
 
    return (

--- a/apps/web/src/features/content/ui/content-list-section.tsx
+++ b/apps/web/src/features/content/ui/content-list-section.tsx
@@ -5,7 +5,12 @@ import {
    CardHeader,
    CardTitle,
 } from "@packages/ui/components/card";
-
+import {
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelHeader,
+   ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
 import { DataTable } from "@packages/ui/components/data-table";
 import {
    Empty,
@@ -22,12 +27,6 @@ import { Archive, FileText, Plus, Search, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/page-header";
-import {
-	ContextPanel,
-	ContextPanelContent,
-	ContextPanelHeader,
-	ContextPanelTitle,
-} from "@packages/ui/components/context-panel";
 import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
 import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import { orpc } from "@/integrations/orpc/client";
@@ -182,19 +181,19 @@ export function ContentListSection() {
    };
 
    useContextPanelInfo(
-		<ContextPanel>
-			<ContextPanelHeader>
-				<ContextPanelTitle>Ações</ContextPanelTitle>
-			</ContextPanelHeader>
-			<ContextPanelContent>
-				<ContextPanelAction
-					icon={Plus}
-					label="Novo conteúdo"
-					onClick={handleCreateNew}
-				/>
-			</ContextPanelContent>
-		</ContextPanel>,
-	);
+      <ContextPanel>
+         <ContextPanelHeader>
+            <ContextPanelTitle>Ações</ContextPanelTitle>
+         </ContextPanelHeader>
+         <ContextPanelContent>
+            <ContextPanelAction
+               icon={Plus}
+               label="Novo conteúdo"
+               onClick={handleCreateNew}
+            />
+         </ContextPanelContent>
+      </ContextPanel>,
+   );
 
    // Table columns
    const columns = useMemo(

--- a/apps/web/src/features/content/ui/content-list-section.tsx
+++ b/apps/web/src/features/content/ui/content-list-section.tsx
@@ -23,9 +23,12 @@ import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/page-header";
 import {
-   ContextPanelAction,
-   ContextPanelSection,
-} from "@/features/context-panel/context-panel-info";
+	ContextPanel,
+	ContextPanelContent,
+	ContextPanelHeader,
+	ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
+import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
 import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import { orpc } from "@/integrations/orpc/client";
 import { ContentMobileCard } from "./content-mobile-card";
@@ -179,14 +182,19 @@ export function ContentListSection() {
    };
 
    useContextPanelInfo(
-      <ContextPanelSection title="Ações">
-         <ContextPanelAction
-            icon={Plus}
-            label="Novo conteúdo"
-            onClick={handleCreateNew}
-         />
-      </ContextPanelSection>,
-   );
+		<ContextPanel>
+			<ContextPanelHeader>
+				<ContextPanelTitle>Ações</ContextPanelTitle>
+			</ContextPanelHeader>
+			<ContextPanelContent>
+				<ContextPanelAction
+					icon={Plus}
+					label="Novo conteúdo"
+					onClick={handleCreateNew}
+				/>
+			</ContextPanelContent>
+		</ContextPanel>,
+	);
 
    // Table columns
    const columns = useMemo(

--- a/apps/web/src/features/context-panel/context-panel-info.tsx
+++ b/apps/web/src/features/context-panel/context-panel-info.tsx
@@ -1,4 +1,13 @@
-import { cn } from "@packages/ui/lib/utils";
+import { Button, buttonVariants } from "@packages/ui/components/button";
+import {
+   Item,
+   ItemActions,
+   ItemContent,
+   ItemMedia,
+   ItemSeparator,
+   ItemTitle,
+} from "@packages/ui/components/item";
+import { type VariantProps } from "class-variance-authority";
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
@@ -6,49 +15,51 @@ export function ContextPanelAction({
    icon: Icon,
    label,
    onClick,
-   variant = "default",
+   variant = "ghost",
 }: {
    icon: LucideIcon;
    label: string;
    onClick: () => void;
-   variant?: "default" | "destructive";
+   variant?: VariantProps<typeof buttonVariants>["variant"];
 }) {
    return (
-      <button
-         className={cn(
-            "flex w-full items-center gap-2.5 px-3 py-1.5 text-sm transition-colors hover:bg-accent",
-            variant === "destructive" &&
-               "text-destructive hover:bg-destructive/10 hover:text-destructive",
-         )}
+      <Button
+         className="w-full justify-start"
          onClick={onClick}
+         size="sm"
          type="button"
+         variant={variant}
       >
-         <Icon
-            className={cn(
-               "size-4 shrink-0 text-muted-foreground",
-               variant === "destructive" && "text-destructive",
-            )}
-         />
+         <Icon className="size-4 shrink-0" />
          {label}
-      </button>
+      </Button>
    );
 }
 
 export function ContextPanelMeta({
+   icon: Icon,
    label,
    value,
 }: {
+   icon: LucideIcon;
    label: string;
    value: ReactNode;
 }) {
    return (
-      <div className="flex items-center justify-between px-3 py-1.5 text-sm">
-         <span className="text-muted-foreground">{label}</span>
-         <span className="ml-4 truncate font-medium">{value}</span>
-      </div>
+      <Item className="px-0" size="sm">
+         <ItemMedia variant="icon">
+            <Icon />
+         </ItemMedia>
+         <ItemContent>
+            <ItemTitle>{label}</ItemTitle>
+         </ItemContent>
+         <ItemActions>
+            <span className="text-sm text-muted-foreground">{value}</span>
+         </ItemActions>
+      </Item>
    );
 }
 
 export function ContextPanelDivider() {
-   return <div className="my-1 border-t" />;
+   return <ItemSeparator className="mx-2 my-1" />;
 }

--- a/apps/web/src/features/context-panel/context-panel-info.tsx
+++ b/apps/web/src/features/context-panel/context-panel-info.tsx
@@ -1,4 +1,4 @@
-import { Button, buttonVariants } from "@packages/ui/components/button";
+import { Button, type buttonVariants } from "@packages/ui/components/button";
 import {
    Item,
    ItemActions,
@@ -7,7 +7,7 @@ import {
    ItemSeparator,
    ItemTitle,
 } from "@packages/ui/components/item";
-import { type VariantProps } from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority";
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 

--- a/apps/web/src/features/context-panel/context-panel-info.tsx
+++ b/apps/web/src/features/context-panel/context-panel-info.tsx
@@ -2,27 +2,6 @@ import { cn } from "@packages/ui/lib/utils";
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
-export function ContextPanelSection({
-   title,
-   children,
-   className,
-}: {
-   title?: string;
-   children: ReactNode;
-   className?: string;
-}) {
-   return (
-      <div className={cn("flex flex-col", className)}>
-         {title && (
-            <div className="bg-muted/50 border-b px-3 py-2 text-xs font-semibold text-foreground">
-               {title}
-            </div>
-         )}
-         <div className="flex flex-col py-1">{children}</div>
-      </div>
-   );
-}
-
 export function ContextPanelAction({
    icon: Icon,
    label,

--- a/apps/web/src/features/context-panel/context-panel.tsx
+++ b/apps/web/src/features/context-panel/context-panel.tsx
@@ -14,9 +14,17 @@ import {
    TooltipTrigger,
 } from "@packages/ui/components/tooltip";
 import { cn } from "@packages/ui/lib/utils";
+import {
+	ContextPanel,
+	ContextPanelContent,
+	ContextPanelHeader,
+	ContextPanelHeaderActions,
+	ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
 import { useStore } from "@tanstack/react-store";
-import { Info, MessageSquare, X } from "lucide-react";
+import { ArrowUpRight, Info, MessageSquare, X } from "lucide-react";
 import type React from "react";
+import { useNavigate, useParams } from "@tanstack/react-router";
 import { type ContextPanelTab, contextPanelStore } from "./context-panel-store";
 import { TecoChatTab } from "./ui/teco-chat-tab";
 import {
@@ -25,18 +33,61 @@ import {
    setActiveTab,
 } from "./use-context-panel";
 
+function InfoContent() {
+   const { infoContent } = useStore(contextPanelStore);
+   if (!infoContent) {
+      return (
+         <ContextPanel>
+            <ContextPanelContent className="flex items-center justify-center p-6">
+               <p className="text-sm text-muted-foreground/50">Sem informações</p>
+            </ContextPanelContent>
+         </ContextPanel>
+      );
+   }
+   return <>{infoContent}</>;
+}
+
+function ChatContent() {
+   const navigate = useNavigate();
+   const { slug, teamSlug } = useParams({
+      from: "/_authenticated/$slug/$teamSlug/_dashboard",
+   });
+
+   return (
+      <ContextPanel>
+         <ContextPanelHeader>
+            <ContextPanelTitle>Chat IA</ContextPanelTitle>
+            <ContextPanelHeaderActions>
+               <Button
+                  className="size-6 rounded"
+                  onClick={() =>
+                     navigate({
+                        to: "/$slug/$teamSlug/chat",
+                        params: { slug, teamSlug },
+                     })
+                  }
+                  size="icon"
+                  type="button"
+                  variant="ghost"
+               >
+                  <ArrowUpRight className="size-3.5" />
+               </Button>
+            </ContextPanelHeaderActions>
+         </ContextPanelHeader>
+         <ContextPanelContent>
+            <TecoChatTab />
+         </ContextPanelContent>
+      </ContextPanel>
+   );
+}
+
 const CHAT_TAB: ContextPanelTab = {
    id: "chat",
    icon: MessageSquare,
    label: "Chat IA",
-   content: <TecoChatTab />,
+   content: <ChatContent />,
    order: 1,
 };
-
-function InfoContent() {
-   const { infoContent } = useStore(contextPanelStore);
-   return <>{infoContent}</>;
-}
 
 const INFO_TAB: ContextPanelTab = {
    id: "info",
@@ -104,10 +155,8 @@ function ContextPanelInner() {
          </SidebarHeader>
 
          {/* Active tab content — inset rounded card on bg-muted */}
-         <SidebarContent className=" overflow-hidden h-full">
-            <div className="h-full rounded-b-xl bg-muted ">
-               {activeTab?.content}
-            </div>
+         <SidebarContent className="h-full overflow-hidden rounded-b-xl bg-muted">
+            {activeTab?.content}
          </SidebarContent>
       </Sidebar>
    );

--- a/apps/web/src/features/context-panel/context-panel.tsx
+++ b/apps/web/src/features/context-panel/context-panel.tsx
@@ -2,6 +2,13 @@
 
 import { Button } from "@packages/ui/components/button";
 import {
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelHeader,
+   ContextPanelHeaderActions,
+   ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
+import {
    Sidebar,
    SidebarContent,
    SidebarHeader,
@@ -14,17 +21,10 @@ import {
    TooltipTrigger,
 } from "@packages/ui/components/tooltip";
 import { cn } from "@packages/ui/lib/utils";
-import {
-	ContextPanel,
-	ContextPanelContent,
-	ContextPanelHeader,
-	ContextPanelHeaderActions,
-	ContextPanelTitle,
-} from "@packages/ui/components/context-panel";
-import { useStore } from "@tanstack/react-store";
-import { ArrowUpRight, Info, MessageSquare, X } from "lucide-react";
-import type React from "react";
 import { useNavigate, useParams } from "@tanstack/react-router";
+import { useStore } from "@tanstack/react-store";
+import { Info, MessageSquare, MoveDiagonalIcon, X } from "lucide-react";
+import type React from "react";
 import { type ContextPanelTab, contextPanelStore } from "./context-panel-store";
 import { TecoChatTab } from "./ui/teco-chat-tab";
 import {
@@ -39,7 +39,9 @@ function InfoContent() {
       return (
          <ContextPanel>
             <ContextPanelContent className="flex items-center justify-center p-6">
-               <p className="text-sm text-muted-foreground/50">Sem informações</p>
+               <p className="text-sm text-muted-foreground/50">
+                  Sem informações
+               </p>
             </ContextPanelContent>
          </ContextPanel>
       );
@@ -56,7 +58,7 @@ function ChatContent() {
    return (
       <ContextPanel>
          <ContextPanelHeader>
-            <ContextPanelTitle>Chat IA</ContextPanelTitle>
+            <ContextPanelTitle>Teco AI</ContextPanelTitle>
             <ContextPanelHeaderActions>
                <Button
                   className="size-6 rounded"
@@ -70,7 +72,7 @@ function ChatContent() {
                   type="button"
                   variant="ghost"
                >
-                  <ArrowUpRight className="size-3.5" />
+                  <MoveDiagonalIcon className="size-4" />
                </Button>
             </ContextPanelHeaderActions>
          </ContextPanelHeader>

--- a/apps/web/src/features/context-panel/ui/teco-chat-tab.tsx
+++ b/apps/web/src/features/context-panel/ui/teco-chat-tab.tsx
@@ -60,6 +60,7 @@ function TecoChatTabInner({
    return (
       <div className="h-full [&_.aui-user-message-content]:bg-background [&_.aui-user-message-content]:text-foreground">
          <Thread
+            onModeChange={onModeChange}
             quickSuggestions={QUICK_SUGGESTIONS}
             recentThreadsSlot={
                <Suspense fallback={null}>
@@ -69,7 +70,6 @@ function TecoChatTabInner({
             welcomeIconUrl="/mascot.svg"
             welcomeSubtitle="Seu assistente de conteúdo com IA."
             welcomeTitle="Como posso te ajudar?"
-            onModeChange={onModeChange}
          />
       </div>
    );
@@ -84,7 +84,7 @@ export function TecoChatTab() {
 
    return (
       <AssistantRuntimeProvider runtime={runtime}>
-         <TecoChatTabInner teamId={activeTeamId} onModeChange={setMode} />
+         <TecoChatTabInner onModeChange={setMode} teamId={activeTeamId} />
       </AssistantRuntimeProvider>
    );
 }

--- a/apps/web/src/features/context-panel/use-context-panel.ts
+++ b/apps/web/src/features/context-panel/use-context-panel.ts
@@ -38,10 +38,11 @@ export const clearInfoContent = () =>
    contextPanelStore.setState((s) => ({ ...s, infoContent: null }));
 
 export const useContextPanelInfo = (content: React.ReactNode) => {
+   // biome-ignore lint/correctness/useExhaustiveDependencies: content is intentionally stable on mount
    useEffect(() => {
       setInfoContent(content);
       return () => clearInfoContent();
-   }, [content]);
+   }, []);
 };
 
 export const useContextPanel = () => {

--- a/apps/web/src/features/context-panel/use-context-panel.ts
+++ b/apps/web/src/features/context-panel/use-context-panel.ts
@@ -38,11 +38,10 @@ export const clearInfoContent = () =>
    contextPanelStore.setState((s) => ({ ...s, infoContent: null }));
 
 export const useContextPanelInfo = (content: React.ReactNode) => {
-   // biome-ignore lint/correctness/useExhaustiveDependencies: content is intentionally stable on mount
    useEffect(() => {
       setInfoContent(content);
       return () => clearInfoContent();
-   }, []);
+   }, [content]);
 };
 
 export const useContextPanel = () => {

--- a/apps/web/src/features/editor/plate/plugins/ai-kit.tsx
+++ b/apps/web/src/features/editor/plate/plugins/ai-kit.tsx
@@ -9,12 +9,6 @@
  */
 
 import { AILoadingBar, AIMenu } from "@packages/ui/components/ai-menu";
-import {
-	NETWORK_AGENT_IDS,
-	completeNetworkAgent,
-	resetAgentNetwork,
-	startNetworkAgent,
-} from "@/features/editor/stores/agent-network-store";
 import { AIAnchorElement, AILeaf } from "@packages/ui/components/ai-node";
 import { CursorOverlayKit } from "@packages/ui/components/editor/plugins/cursor-overlay-kit";
 import { MarkdownKit } from "@packages/ui/components/editor/plugins/markdown-kit";
@@ -30,6 +24,12 @@ import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
 import { getPluginType, KEYS, PathApi } from "platejs";
 import { usePluginOption } from "platejs/react";
 import type { ChatChunk } from "@/features/editor/schemas";
+import {
+   completeNetworkAgent,
+   NETWORK_AGENT_IDS,
+   resetAgentNetwork,
+   startNetworkAgent,
+} from "@/features/editor/stores/agent-network-store";
 import { client } from "@/integrations/orpc/client";
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/features/editor/plate/ui/editor-context-panel-tabs.tsx
+++ b/apps/web/src/features/editor/plate/ui/editor-context-panel-tabs.tsx
@@ -1,18 +1,18 @@
 "use client";
 
 import type { ContentMeta } from "@packages/database/schemas/content";
+import {
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelHeader,
+   ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
 import { Link2, Settings2 } from "lucide-react";
 import { useEffect } from "react";
 import {
    registerTab,
    unregisterTab,
 } from "@/features/context-panel/use-context-panel";
-import {
-	ContextPanel,
-	ContextPanelContent,
-	ContextPanelHeader,
-	ContextPanelTitle,
-} from "@packages/ui/components/context-panel";
 import { FrontmatterSection } from "../../ui/frontmatter-section";
 import { InternalLinksSidebar } from "./internal-links-sidebar";
 

--- a/apps/web/src/features/editor/plate/ui/editor-context-panel-tabs.tsx
+++ b/apps/web/src/features/editor/plate/ui/editor-context-panel-tabs.tsx
@@ -1,58 +1,26 @@
 "use client";
 
-import type { ContentMeta } from "@packages/database/schemas/content";
 import {
    ContextPanel,
    ContextPanelContent,
    ContextPanelHeader,
    ContextPanelTitle,
 } from "@packages/ui/components/context-panel";
-import { Link2, Settings2 } from "lucide-react";
+import { Link2 } from "lucide-react";
 import { useEffect } from "react";
 import {
    registerTab,
    unregisterTab,
 } from "@/features/context-panel/use-context-panel";
-import { FrontmatterSection } from "../../ui/frontmatter-section";
 import { InternalLinksSidebar } from "./internal-links-sidebar";
 
 interface EditorContextPanelTabsProps {
    contentId: string;
-   meta: ContentMeta;
-   onChange: (meta: ContentMeta) => void;
-   readOnly: boolean;
 }
 
 export function EditorContextPanelTabs({
    contentId,
-   meta,
-   onChange,
-   readOnly,
 }: EditorContextPanelTabsProps) {
-   // Settings tab: re-registers when meta/onChange/readOnly change so panel always has fresh data
-   useEffect(() => {
-      registerTab({
-         id: "settings",
-         icon: Settings2,
-         label: "Metadados",
-         content: (
-            <ContextPanel>
-               <ContextPanelHeader>
-                  <ContextPanelTitle>Metadados</ContextPanelTitle>
-               </ContextPanelHeader>
-               <ContextPanelContent>
-                  <FrontmatterSection
-                     meta={meta}
-                     onChange={onChange}
-                     readOnly={readOnly}
-                  />
-               </ContextPanelContent>
-            </ContextPanel>
-         ),
-         order: 1,
-      });
-   }, [meta, onChange, readOnly]);
-
    // Links tab: registers once per contentId
    useEffect(() => {
       registerTab({
@@ -75,13 +43,6 @@ export function EditorContextPanelTabs({
          unregisterTab("links");
       };
    }, [contentId]);
-
-   // Clean up settings tab on unmount
-   useEffect(() => {
-      return () => {
-         unregisterTab("settings");
-      };
-   }, []);
 
    return null;
 }

--- a/apps/web/src/features/editor/plate/ui/editor-context-panel-tabs.tsx
+++ b/apps/web/src/features/editor/plate/ui/editor-context-panel-tabs.tsx
@@ -7,6 +7,12 @@ import {
    registerTab,
    unregisterTab,
 } from "@/features/context-panel/use-context-panel";
+import {
+	ContextPanel,
+	ContextPanelContent,
+	ContextPanelHeader,
+	ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
 import { FrontmatterSection } from "../../ui/frontmatter-section";
 import { InternalLinksSidebar } from "./internal-links-sidebar";
 
@@ -30,11 +36,18 @@ export function EditorContextPanelTabs({
          icon: Settings2,
          label: "Metadados",
          content: (
-            <FrontmatterSection
-               meta={meta}
-               onChange={onChange}
-               readOnly={readOnly}
-            />
+            <ContextPanel>
+               <ContextPanelHeader>
+                  <ContextPanelTitle>Metadados</ContextPanelTitle>
+               </ContextPanelHeader>
+               <ContextPanelContent>
+                  <FrontmatterSection
+                     meta={meta}
+                     onChange={onChange}
+                     readOnly={readOnly}
+                  />
+               </ContextPanelContent>
+            </ContextPanel>
          ),
          order: 1,
       });
@@ -46,7 +59,16 @@ export function EditorContextPanelTabs({
          id: "links",
          icon: Link2,
          label: "Links do Cluster",
-         content: <InternalLinksSidebar contentId={contentId} />,
+         content: (
+            <ContextPanel>
+               <ContextPanelHeader>
+                  <ContextPanelTitle>Links do Cluster</ContextPanelTitle>
+               </ContextPanelHeader>
+               <ContextPanelContent>
+                  <InternalLinksSidebar contentId={contentId} />
+               </ContextPanelContent>
+            </ContextPanel>
+         ),
          order: 2,
       });
       return () => {

--- a/apps/web/src/features/editor/ui/editor-fixed-toolbar.tsx
+++ b/apps/web/src/features/editor/ui/editor-fixed-toolbar.tsx
@@ -2,276 +2,280 @@
 
 import { Button } from "@packages/ui/components/button";
 import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
+   DropdownMenu,
+   DropdownMenuContent,
+   DropdownMenuItem,
+   DropdownMenuTrigger,
 } from "@packages/ui/components/dropdown-menu";
 import { Separator } from "@packages/ui/components/separator";
 import {
-	Tooltip,
-	TooltipContent,
-	TooltipProvider,
-	TooltipTrigger,
+   Tooltip,
+   TooltipContent,
+   TooltipProvider,
+   TooltipTrigger,
 } from "@packages/ui/components/tooltip";
 import { cn } from "@packages/ui/lib/utils";
 import { triggerFloatingLink } from "@platejs/link/react";
 import {
-	useMarkToolbarButton,
-	useMarkToolbarButtonState,
+   useMarkToolbarButton,
+   useMarkToolbarButtonState,
 } from "@platejs/utils/react";
 import { useStore } from "@tanstack/react-store";
 import {
-	Archive,
-	Bold,
-	Check,
-	ChevronDown,
-	FileText,
-	Globe,
-	Info,
-	Italic,
-	Link2,
-	Loader2,
-	MessageSquare,
-	Save,
-	Underline,
+   Archive,
+   Bold,
+   Check,
+   ChevronDown,
+   FileText,
+   Globe,
+   Info,
+   Italic,
+   Link2,
+   Loader2,
+   MessageSquare,
+   Save,
+   Underline,
 } from "lucide-react";
 import { useEditorRef } from "platejs/react";
 import { contextPanelStore } from "@/features/context-panel/context-panel-store";
 import {
-	closeContextPanel,
-	openContextPanel,
-	setActiveTab,
+   closeContextPanel,
+   openContextPanel,
+   setActiveTab,
 } from "@/features/context-panel/use-context-panel";
 
 type ContentStatus = "draft" | "published" | "archived";
 
 interface EditorFixedToolbarProps {
-	status?: ContentStatus;
-	isSaving?: boolean;
-	onSave?: () => void;
-	onStatusChange?: (status: ContentStatus) => void;
+   status?: ContentStatus;
+   isSaving?: boolean;
+   onSave?: () => void;
+   onStatusChange?: (status: ContentStatus) => void;
 }
 
 const STATUS_CONFIG: Record<
-	ContentStatus,
-	{ label: string; text: string; Icon: React.ElementType }
+   ContentStatus,
+   { label: string; text: string; Icon: React.ElementType }
 > = {
-	draft: {
-		label: "Rascunho",
-		text: "text-amber-600 dark:text-amber-400",
-		Icon: FileText,
-	},
-	published: {
-		label: "Publicado",
-		text: "text-emerald-600 dark:text-emerald-400",
-		Icon: Globe,
-	},
-	archived: {
-		label: "Arquivado",
-		text: "text-muted-foreground",
-		Icon: Archive,
-	},
+   draft: {
+      label: "Rascunho",
+      text: "text-amber-600 dark:text-amber-400",
+      Icon: FileText,
+   },
+   published: {
+      label: "Publicado",
+      text: "text-emerald-600 dark:text-emerald-400",
+      Icon: Globe,
+   },
+   archived: {
+      label: "Arquivado",
+      text: "text-muted-foreground",
+      Icon: Archive,
+   },
 };
 
 // Static tabs always present in the context panel
 const STATIC_TABS = [
-	{ id: "info", icon: Info, label: "Informações" },
-	{ id: "chat", icon: MessageSquare, label: "Chat IA" },
+   { id: "info", icon: Info, label: "Informações" },
+   { id: "chat", icon: MessageSquare, label: "Chat IA" },
 ];
 
 function MarkButton({
-	nodeType,
-	icon,
-	tooltip,
+   nodeType,
+   icon,
+   tooltip,
 }: {
-	nodeType: string;
-	icon: React.ReactNode;
-	tooltip: string;
+   nodeType: string;
+   icon: React.ReactNode;
+   tooltip: string;
 }) {
-	const state = useMarkToolbarButtonState({ nodeType });
-	const { props } = useMarkToolbarButton(state);
+   const state = useMarkToolbarButtonState({ nodeType });
+   const { props } = useMarkToolbarButton(state);
 
-	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<Button
-					className={cn(
-						"size-8 rounded",
-						state.pressed && "bg-accent text-accent-foreground",
-					)}
-					size="icon"
-					type="button"
-					variant="ghost"
-					{...props}
-				>
-					{icon}
-				</Button>
-			</TooltipTrigger>
-			<TooltipContent>{tooltip}</TooltipContent>
-		</Tooltip>
-	);
+   return (
+      <Tooltip>
+         <TooltipTrigger asChild>
+            <Button
+               className={cn(
+                  "size-8 rounded",
+                  state.pressed && "bg-accent text-accent-foreground",
+               )}
+               size="icon"
+               type="button"
+               variant="ghost"
+               {...props}
+            >
+               {icon}
+            </Button>
+         </TooltipTrigger>
+         <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+   );
 }
 
 export function EditorFixedToolbar({
-	status = "draft",
-	isSaving,
-	onSave,
-	onStatusChange,
+   status = "draft",
+   isSaving,
+   onSave,
+   onStatusChange,
 }: EditorFixedToolbarProps) {
-	const editor = useEditorRef();
-	const cfg = STATUS_CONFIG[status] ?? STATUS_CONFIG.draft;
+   const editor = useEditorRef();
+   const cfg = STATUS_CONFIG[status] ?? STATUS_CONFIG.draft;
 
-	const { isOpen, activeTabId, dynamicTabs } = useStore(contextPanelStore);
+   const { isOpen, activeTabId, dynamicTabs } = useStore(contextPanelStore);
 
-	const handleLinkClick = () => {
-		triggerFloatingLink(editor, { focused: true });
-	};
+   const handleLinkClick = () => {
+      triggerFloatingLink(editor, { focused: true });
+   };
 
-	const handleTabClick = (tabId: string) => {
-		if (isOpen && activeTabId === tabId) {
-			closeContextPanel();
-		} else {
-			setActiveTab(tabId);
-			openContextPanel();
-		}
-	};
+   const handleTabClick = (tabId: string) => {
+      if (isOpen && activeTabId === tabId) {
+         closeContextPanel();
+      } else {
+         setActiveTab(tabId);
+         openContextPanel();
+      }
+   };
 
-	const allTabs = [
-		...STATIC_TABS,
-		...dynamicTabs
-			.slice()
-			.sort((a, b) => (a.order ?? 99) - (b.order ?? 99))
-			.map((t) => ({ id: t.id, icon: t.icon, label: t.label })),
-	];
+   const allTabs = [
+      ...STATIC_TABS,
+      ...dynamicTabs
+         .slice()
+         .sort((a, b) => (a.order ?? 99) - (b.order ?? 99))
+         .map((t) => ({ id: t.id, icon: t.icon, label: t.label })),
+   ];
 
-	return (
-		<TooltipProvider>
-			<div className="flex h-12 items-center gap-1.5 border-b px-3 bg-background sticky top-0 z-10">
-				{/* Formatting marks */}
-				<div className="flex items-center gap-0.5">
-					<MarkButton
-						icon={<Bold className="size-4" />}
-						nodeType="bold"
-						tooltip="Negrito ⌘B"
-					/>
-					<MarkButton
-						icon={<Italic className="size-4" />}
-						nodeType="italic"
-						tooltip="Itálico ⌘I"
-					/>
-					<MarkButton
-						icon={<Underline className="size-4" />}
-						nodeType="underline"
-						tooltip="Sublinhado ⌘U"
-					/>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								className="size-8 rounded"
-								onClick={handleLinkClick}
-								size="icon"
-								type="button"
-								variant="ghost"
-							>
-								<Link2 className="size-4" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Link ⌘K</TooltipContent>
-					</Tooltip>
-				</div>
+   return (
+      <TooltipProvider>
+         <div className="flex h-12 items-center gap-1.5 border-b px-3 bg-background sticky top-0 z-10">
+            {/* Formatting marks */}
+            <div className="flex items-center gap-0.5">
+               <MarkButton
+                  icon={<Bold className="size-4" />}
+                  nodeType="bold"
+                  tooltip="Negrito ⌘B"
+               />
+               <MarkButton
+                  icon={<Italic className="size-4" />}
+                  nodeType="italic"
+                  tooltip="Itálico ⌘I"
+               />
+               <MarkButton
+                  icon={<Underline className="size-4" />}
+                  nodeType="underline"
+                  tooltip="Sublinhado ⌘U"
+               />
+               <Tooltip>
+                  <TooltipTrigger asChild>
+                     <Button
+                        className="size-8 rounded"
+                        onClick={handleLinkClick}
+                        size="icon"
+                        type="button"
+                        variant="ghost"
+                     >
+                        <Link2 className="size-4" />
+                     </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Link ⌘K</TooltipContent>
+               </Tooltip>
+            </div>
 
-				{/* Spacer */}
-				<div className="flex-1" />
+            {/* Spacer */}
+            <div className="flex-1" />
 
-				{/* Status */}
-				{onStatusChange && (
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<Button
-								className="h-8 gap-2 rounded px-3 text-sm font-medium"
-								type="button"
-								variant="ghost"
-							>
-								<cfg.Icon className={cn("size-3.5 shrink-0", cfg.text)} />
-								<span className={cn(cfg.text)}>{cfg.label}</span>
-								<ChevronDown className="size-3.5 text-muted-foreground" />
-							</Button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="end" className="w-44">
-							{(["draft", "published", "archived"] as ContentStatus[]).map(
-								(s) => {
-									const item = STATUS_CONFIG[s];
-									return (
-										<DropdownMenuItem
-											className="gap-2.5 py-2 text-sm"
-											key={s}
-											onClick={() => onStatusChange(s)}
-										>
-											<item.Icon
-												className={cn("size-4 shrink-0", item.text)}
-											/>
-											<span className={cn("flex-1", item.text)}>
-												{item.label}
-											</span>
-											{status === s && (
-												<Check className="size-3.5 text-muted-foreground" />
-											)}
-										</DropdownMenuItem>
-									);
-								},
-							)}
-						</DropdownMenuContent>
-					</DropdownMenu>
-				)}
+            {/* Status */}
+            {onStatusChange && (
+               <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                     <Button
+                        className="h-8 gap-2 rounded px-3 text-sm font-medium"
+                        type="button"
+                        variant="ghost"
+                     >
+                        <cfg.Icon
+                           className={cn("size-3.5 shrink-0", cfg.text)}
+                        />
+                        <span className={cn(cfg.text)}>{cfg.label}</span>
+                        <ChevronDown className="size-3.5 text-muted-foreground" />
+                     </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-44">
+                     {(
+                        ["draft", "published", "archived"] as ContentStatus[]
+                     ).map((s) => {
+                        const item = STATUS_CONFIG[s];
+                        return (
+                           <DropdownMenuItem
+                              className="gap-2.5 py-2 text-sm"
+                              key={s}
+                              onClick={() => onStatusChange(s)}
+                           >
+                              <item.Icon
+                                 className={cn("size-4 shrink-0", item.text)}
+                              />
+                              <span className={cn("flex-1", item.text)}>
+                                 {item.label}
+                              </span>
+                              {status === s && (
+                                 <Check className="size-3.5 text-muted-foreground" />
+                              )}
+                           </DropdownMenuItem>
+                        );
+                     })}
+                  </DropdownMenuContent>
+               </DropdownMenu>
+            )}
 
-				<Separator className="mx-0.5 h-4" orientation="vertical" />
+            <Separator className="mx-0.5 h-4" orientation="vertical" />
 
-				{/* Save */}
-				<Button
-					className="h-8 gap-2 rounded px-4 text-sm"
-					disabled={isSaving}
-					onClick={onSave}
-					size="sm"
-					type="button"
-					variant="default"
-				>
-					{isSaving ? (
-						<Loader2 className="size-4 animate-spin" />
-					) : (
-						<Save className="size-4" />
-					)}
-					Salvar
-				</Button>
+            {/* Save */}
+            <Button
+               className="h-8 gap-2 rounded px-4 text-sm"
+               disabled={isSaving}
+               onClick={onSave}
+               size="sm"
+               type="button"
+               variant="default"
+            >
+               {isSaving ? (
+                  <Loader2 className="size-4 animate-spin" />
+               ) : (
+                  <Save className="size-4" />
+               )}
+               Salvar
+            </Button>
 
-				<Separator className="mx-0.5 h-4" orientation="vertical" />
+            <Separator className="mx-0.5 h-4" orientation="vertical" />
 
-				{/* Context panel tab buttons */}
-				<div className="flex items-center gap-0.5">
-					{allTabs.map((tab) => {
-						const isActive = isOpen && activeTabId === tab.id;
-						return (
-							<Tooltip key={tab.id}>
-								<TooltipTrigger asChild>
-									<Button
-										className={cn(
-											"size-8 rounded",
-											isActive && "bg-accent text-accent-foreground",
-										)}
-										onClick={() => handleTabClick(tab.id)}
-										size="icon"
-										type="button"
-										variant="ghost"
-									>
-										<tab.icon className="size-4" />
-									</Button>
-								</TooltipTrigger>
-								<TooltipContent side="bottom">{tab.label}</TooltipContent>
-							</Tooltip>
-						);
-					})}
-				</div>
-			</div>
-		</TooltipProvider>
-	);
+            {/* Context panel tab buttons */}
+            <div className="flex items-center gap-0.5">
+               {allTabs.map((tab) => {
+                  const isActive = isOpen && activeTabId === tab.id;
+                  return (
+                     <Tooltip key={tab.id}>
+                        <TooltipTrigger asChild>
+                           <Button
+                              className={cn(
+                                 "size-8 rounded",
+                                 isActive && "bg-accent text-accent-foreground",
+                              )}
+                              onClick={() => handleTabClick(tab.id)}
+                              size="icon"
+                              type="button"
+                              variant="ghost"
+                           >
+                              <tab.icon className="size-4" />
+                           </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">
+                           {tab.label}
+                        </TooltipContent>
+                     </Tooltip>
+                  );
+               })}
+            </div>
+         </div>
+      </TooltipProvider>
+   );
 }

--- a/apps/web/src/features/editor/ui/editor-meta-panel.tsx
+++ b/apps/web/src/features/editor/ui/editor-meta-panel.tsx
@@ -1,0 +1,236 @@
+import type { ContentMeta } from "@packages/database/schemas/content";
+import {
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelHeader,
+   ContextPanelHeaderActions,
+   ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
+import {
+   Field,
+   FieldError,
+   FieldGroup,
+   FieldLabel,
+} from "@packages/ui/components/field";
+import { Button } from "@packages/ui/components/button";
+import { Input } from "@packages/ui/components/input";
+import { MultiSelect } from "@packages/ui/components/multi-select";
+import { Textarea } from "@packages/ui/components/textarea";
+import { useForm } from "@tanstack/react-form";
+import { Check, Pencil } from "lucide-react";
+import { type FormEvent, useCallback, useState, useTransition } from "react";
+import { z } from "zod";
+
+const metaSchema = z.object({
+   title: z.string().min(1, "O título é obrigatório."),
+   description: z.string(),
+   slug: z.string().min(1, "O slug é obrigatório."),
+   keywords: z.array(z.string()),
+});
+
+interface EditorMetaPanelProps {
+   meta: ContentMeta;
+   onSave: (values: ContentMeta) => Promise<void>;
+}
+
+export function EditorMetaPanel({ meta, onSave }: EditorMetaPanelProps) {
+   const [isPending, startTransition] = useTransition();
+   const [isEditing, setIsEditing] = useState(false);
+
+   const form = useForm({
+      defaultValues: {
+         title: meta.title,
+         description: meta.description,
+         slug: meta.slug,
+         keywords: meta.keywords ?? [],
+      },
+      onSubmit: async ({ value }) => {
+         await onSave({ ...meta, ...value });
+         setIsEditing(false);
+      },
+      validators: { onBlur: metaSchema },
+   });
+
+   const handleSubmit = useCallback(
+      (e: FormEvent) => {
+         e.preventDefault();
+         e.stopPropagation();
+         startTransition(async () => {
+            await form.handleSubmit();
+         });
+      },
+      [form],
+   );
+
+   return (
+      <ContextPanel>
+         <form className="contents" onSubmit={handleSubmit}>
+            <ContextPanelHeader>
+               <ContextPanelTitle>Frontmatter</ContextPanelTitle>
+               <ContextPanelHeaderActions>
+                  {isEditing ? (
+                     <form.Subscribe>
+                        {(state) => (
+                           <Button
+                              className="size-6 rounded"
+                              disabled={!state.canSubmit || isPending}
+                              size="icon"
+                              type="submit"
+                              variant="ghost"
+                           >
+                              <Check className="size-4" />
+                           </Button>
+                        )}
+                     </form.Subscribe>
+                  ) : (
+                     <Button
+                        className="size-6 rounded"
+                        onClick={() => setIsEditing(true)}
+                        size="icon"
+                        type="button"
+                        variant="ghost"
+                     >
+                        <Pencil className="size-4" />
+                     </Button>
+                  )}
+               </ContextPanelHeaderActions>
+            </ContextPanelHeader>
+
+            <ContextPanelContent>
+               <FieldGroup>
+                  <form.Field name="title">
+                     {(field) => {
+                        const isInvalid =
+                           field.state.meta.isTouched &&
+                           !field.state.meta.isValid;
+                        return (
+                           <Field data-invalid={isInvalid}>
+                              <FieldLabel htmlFor={field.name}>
+                                 Título
+                              </FieldLabel>
+                              <Input
+                                 aria-invalid={isInvalid}
+                                 disabled={!isEditing || isPending}
+                                 id={field.name}
+                                 name={field.name}
+                                 onBlur={field.handleBlur}
+                                 onChange={(e) =>
+                                    field.handleChange(e.target.value)
+                                 }
+                                 placeholder="Título do conteúdo"
+                                 value={field.state.value}
+                              />
+                              {isInvalid && (
+                                 <FieldError errors={field.state.meta.errors} />
+                              )}
+                           </Field>
+                        );
+                     }}
+                  </form.Field>
+
+                  <form.Field name="description">
+                     {(field) => {
+                        const isInvalid =
+                           field.state.meta.isTouched &&
+                           !field.state.meta.isValid;
+                        return (
+                           <Field data-invalid={isInvalid}>
+                              <FieldLabel htmlFor={field.name}>
+                                 Descrição
+                              </FieldLabel>
+                              <Textarea
+                                 aria-invalid={isInvalid}
+                                 disabled={!isEditing || isPending}
+                                 id={field.name}
+                                 name={field.name}
+                                 onBlur={field.handleBlur}
+                                 onChange={(e) =>
+                                    field.handleChange(e.target.value)
+                                 }
+                                 placeholder="Meta descrição"
+                                 rows={3}
+                                 value={field.state.value}
+                              />
+                              {isInvalid && (
+                                 <FieldError errors={field.state.meta.errors} />
+                              )}
+                           </Field>
+                        );
+                     }}
+                  </form.Field>
+
+                  <form.Field name="slug">
+                     {(field) => {
+                        const isInvalid =
+                           field.state.meta.isTouched &&
+                           !field.state.meta.isValid;
+                        return (
+                           <Field data-invalid={isInvalid}>
+                              <FieldLabel htmlFor={field.name}>Slug</FieldLabel>
+                              <Input
+                                 aria-invalid={isInvalid}
+                                 disabled={!isEditing || isPending}
+                                 id={field.name}
+                                 name={field.name}
+                                 onBlur={field.handleBlur}
+                                 onChange={(e) =>
+                                    field.handleChange(e.target.value)
+                                 }
+                                 placeholder="url-do-conteudo"
+                                 value={field.state.value}
+                              />
+                              {isInvalid && (
+                                 <FieldError errors={field.state.meta.errors} />
+                              )}
+                           </Field>
+                        );
+                     }}
+                  </form.Field>
+
+                  <form.Field name="keywords">
+                     {(field) => {
+                        const options = field.state.value.map((kw) => ({
+                           label: kw,
+                           value: kw,
+                        }));
+                        return (
+                           <Field>
+                              <FieldLabel>Keywords</FieldLabel>
+                              <div
+                                 className={
+                                    !isEditing
+                                       ? "pointer-events-none opacity-50"
+                                       : undefined
+                                 }
+                              >
+                                 <MultiSelect
+                                    onChange={(selected) =>
+                                       field.handleChange(selected)
+                                    }
+                                    onCreate={(name) => {
+                                       const trimmed = name.trim();
+                                       if (
+                                          trimmed &&
+                                          !field.state.value.includes(trimmed)
+                                       ) {
+                                          field.handleChange([
+                                             ...field.state.value,
+                                             trimmed,
+                                          ]);
+                                       }
+                                    }}
+                                    options={options}
+                                    placeholder="Adicionar keyword..."
+                                    selected={field.state.value}
+                                 />
+                              </div>
+                           </Field>
+                        );
+                     }}
+                  </form.Field>
+               </FieldGroup>
+            </ContextPanelContent>
+         </form>
+      </ContextPanel>
+   );
+}

--- a/apps/web/src/features/editor/ui/editor-meta-panel.tsx
+++ b/apps/web/src/features/editor/ui/editor-meta-panel.tsx
@@ -1,4 +1,5 @@
 import type { ContentMeta } from "@packages/database/schemas/content";
+import { Button } from "@packages/ui/components/button";
 import {
    ContextPanel,
    ContextPanelContent,
@@ -12,7 +13,6 @@ import {
    FieldGroup,
    FieldLabel,
 } from "@packages/ui/components/field";
-import { Button } from "@packages/ui/components/button";
 import { Input } from "@packages/ui/components/input";
 import { MultiSelect } from "@packages/ui/components/multi-select";
 import { Textarea } from "@packages/ui/components/textarea";

--- a/apps/web/src/features/editor/ui/editor-page.tsx
+++ b/apps/web/src/features/editor/ui/editor-page.tsx
@@ -11,82 +11,82 @@ import { EditorContextPanelTabs } from "../plate/ui/editor-context-panel-tabs";
 type ContentStatus = "draft" | "published" | "archived";
 
 interface EditorPageProps {
-	contentId: string;
+   contentId: string;
 }
 
 export function EditorPage({ contentId }: EditorPageProps) {
-	const { data: content } = useSuspenseQuery(
-		orpc.content.getById.queryOptions({ input: { id: contentId } }),
-	);
+   const { data: content } = useSuspenseQuery(
+      orpc.content.getById.queryOptions({ input: { id: contentId } }),
+   );
 
-	const [meta, setMeta] = useState<ContentMeta>(
-		() => content.meta ?? { title: "", description: "", slug: "" },
-	);
-	const [isSaving, setIsSaving] = useState(false);
+   const [meta, setMeta] = useState<ContentMeta>(
+      () => content.meta ?? { title: "", description: "", slug: "" },
+   );
+   const [isSaving, setIsSaving] = useState(false);
 
-	const editorValueRef = useRef<Value | undefined>(undefined);
+   const editorValueRef = useRef<Value | undefined>(undefined);
 
-	const updateMutation = useMutation(orpc.content.update.mutationOptions({}));
-	const publishMutation = useMutation(
-		orpc.content.publish.mutationOptions({}),
-	);
-	const archiveMutation = useMutation(
-		orpc.content.archive.mutationOptions({}),
-	);
-	const moveToDraftMutation = useMutation(
-		orpc.content.moveToDraft.mutationOptions({}),
-	);
+   const updateMutation = useMutation(orpc.content.update.mutationOptions({}));
+   const publishMutation = useMutation(
+      orpc.content.publish.mutationOptions({}),
+   );
+   const archiveMutation = useMutation(
+      orpc.content.archive.mutationOptions({}),
+   );
+   const moveToDraftMutation = useMutation(
+      orpc.content.moveToDraft.mutationOptions({}),
+   );
 
-	const handleSave = useCallback(async () => {
-		setIsSaving(true);
-		try {
-			await updateMutation.mutateAsync({
-				id: contentId,
-				data: { meta, body: JSON.stringify(editorValueRef.current) },
-			});
-		} finally {
-			setIsSaving(false);
-		}
-	}, [contentId, meta, updateMutation]);
+   const handleSave = useCallback(async () => {
+      setIsSaving(true);
+      try {
+         await updateMutation.mutateAsync({
+            id: contentId,
+            data: { meta, body: JSON.stringify(editorValueRef.current) },
+         });
+      } finally {
+         setIsSaving(false);
+      }
+   }, [contentId, meta, updateMutation]);
 
-	const handleStatusChange = useCallback(
-		async (newStatus: ContentStatus) => {
-			if (newStatus === "published") {
-				await publishMutation.mutateAsync({ id: contentId });
-			} else if (newStatus === "archived") {
-				await archiveMutation.mutateAsync({ id: contentId });
-			} else {
-				await moveToDraftMutation.mutateAsync({ id: contentId });
-			}
-		},
-		[contentId, publishMutation, archiveMutation, moveToDraftMutation],
-	);
+   const handleStatusChange = useCallback(
+      async (newStatus: ContentStatus) => {
+         if (newStatus === "published") {
+            await publishMutation.mutateAsync({ id: contentId });
+         } else if (newStatus === "archived") {
+            await archiveMutation.mutateAsync({ id: contentId });
+         } else {
+            await moveToDraftMutation.mutateAsync({ id: contentId });
+         }
+      },
+      [contentId, publishMutation, archiveMutation, moveToDraftMutation],
+   );
 
-	return (
-		<div className="flex h-full flex-col">
-			<EditorContextPanelTabs
-				contentId={contentId}
-				meta={meta}
-				onChange={setMeta}
-				readOnly={content.status === "archived"}
-			/>
-			<PlateEditor
-				contentId={contentId}
-				editable={content.status !== "archived"}
-				initialValue={
-					content?.body ? (JSON.parse(content.body) as Value) : undefined
-				}
-				isSaving={isSaving}
-				key={contentId}
-				onChange={(value) => {
-					editorValueRef.current = value;
-				}}
-				onSave={handleSave}
-				onStatusChange={handleStatusChange}
-				status={content.status as ContentStatus}
-				teamId={content.teamId ?? undefined}
-				writerId={content.writerId ?? undefined}
-			/>
-		</div>
-	);
+   return (
+      <div className="flex h-full flex-col">
+         <EditorContextPanelTabs
+            contentId={contentId}
+            meta={meta}
+            onChange={setMeta}
+            readOnly={content.status === "archived"}
+         />
+         <PlateEditor
+            contentId={contentId}
+            editable={content.status !== "archived"}
+            initialValue={
+               content?.body ? (JSON.parse(content.body) as Value) : undefined
+            }
+            isSaving={isSaving}
+            key={contentId}
+            onChange={(value) => {
+               editorValueRef.current = value;
+            }}
+            onSave={handleSave}
+            onStatusChange={handleStatusChange}
+            status={content.status as ContentStatus}
+            teamId={content.teamId ?? undefined}
+            writerId={content.writerId ?? undefined}
+         />
+      </div>
+   );
 }

--- a/apps/web/src/features/editor/ui/editor-page.tsx
+++ b/apps/web/src/features/editor/ui/editor-page.tsx
@@ -5,11 +5,10 @@ import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import type { Value } from "platejs";
 import { useCallback, useRef, useState } from "react";
 import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
-import { EditorMetaPanel } from "./editor-meta-panel";
 import { orpc } from "@/integrations/orpc/client";
 import { PlateEditor } from "../plate/plate-editor";
 import { EditorContextPanelTabs } from "../plate/ui/editor-context-panel-tabs";
-
+import { EditorMetaPanel } from "./editor-meta-panel";
 
 type ContentStatus = "draft" | "published" | "archived";
 
@@ -70,7 +69,10 @@ export function EditorPage({ contentId }: EditorPageProps) {
          setMeta(values);
          await updateMutation.mutateAsync({
             id: contentId,
-            data: { meta: values, body: JSON.stringify(editorValueRef.current) },
+            data: {
+               meta: values,
+               body: JSON.stringify(editorValueRef.current),
+            },
          });
       },
       [contentId, updateMutation],

--- a/apps/web/src/features/editor/ui/editor-page.tsx
+++ b/apps/web/src/features/editor/ui/editor-page.tsx
@@ -4,9 +4,12 @@ import type { ContentMeta } from "@packages/database/schemas/content";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import type { Value } from "platejs";
 import { useCallback, useRef, useState } from "react";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
+import { EditorMetaPanel } from "./editor-meta-panel";
 import { orpc } from "@/integrations/orpc/client";
 import { PlateEditor } from "../plate/plate-editor";
 import { EditorContextPanelTabs } from "../plate/ui/editor-context-panel-tabs";
+
 
 type ContentStatus = "draft" | "published" | "archived";
 
@@ -62,14 +65,22 @@ export function EditorPage({ contentId }: EditorPageProps) {
       [contentId, publishMutation, archiveMutation, moveToDraftMutation],
    );
 
+   const handleMetaSave = useCallback(
+      async (values: ContentMeta) => {
+         setMeta(values);
+         await updateMutation.mutateAsync({
+            id: contentId,
+            data: { meta: values, body: JSON.stringify(editorValueRef.current) },
+         });
+      },
+      [contentId, updateMutation],
+   );
+
+   useContextPanelInfo(<EditorMetaPanel meta={meta} onSave={handleMetaSave} />);
+
    return (
       <div className="flex h-full flex-col">
-         <EditorContextPanelTabs
-            contentId={contentId}
-            meta={meta}
-            onChange={setMeta}
-            readOnly={content.status === "archived"}
-         />
+         <EditorContextPanelTabs contentId={contentId} />
          <PlateEditor
             contentId={contentId}
             editable={content.status !== "archived"}

--- a/apps/web/src/features/experiments/ui/experiment-builder.tsx
+++ b/apps/web/src/features/experiments/ui/experiment-builder.tsx
@@ -10,7 +10,7 @@ import { Skeleton } from "@packages/ui/components/skeleton";
 import { cn } from "@packages/ui/lib/utils";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { CheckCheck, Pause, Play, Trash2 } from "lucide-react";
+import { Activity, CheckCheck, GitBranch, Pause, Play, Tag, Target, Trash2 } from "lucide-react";
 import { Suspense, useCallback, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { toast } from "sonner";
@@ -188,18 +188,21 @@ function ExperimentBuilderEditContent({
          </ContextPanelHeader>
          <ContextPanelContent>
             <ContextPanelMeta
+               icon={Activity}
                label="Status"
                value={STATUS_LABELS[experiment.status] ?? experiment.status}
             />
             <ContextPanelMeta
+               icon={Tag}
                label="Tipo"
                value={TARGET_TYPE_LABELS[experiment.targetType] ?? experiment.targetType}
             />
             <ContextPanelMeta
+               icon={Target}
                label="Meta"
                value={GOAL_LABELS[experiment.goal] ?? experiment.goal}
             />
-            <ContextPanelMeta label="Variantes" value={variantCount} />
+            <ContextPanelMeta icon={GitBranch} label="Variantes" value={variantCount} />
             <ContextPanelDivider />
             {canStart && (
                <ContextPanelAction

--- a/apps/web/src/features/experiments/ui/experiment-builder.tsx
+++ b/apps/web/src/features/experiments/ui/experiment-builder.tsx
@@ -1,26 +1,35 @@
+import { Button } from "@packages/ui/components/button";
 import {
    ContextPanel,
    ContextPanelContent,
    ContextPanelHeader,
    ContextPanelTitle,
 } from "@packages/ui/components/context-panel";
-import { Button } from "@packages/ui/components/button";
 import { createErrorFallback } from "@packages/ui/components/error-fallback";
 import { Skeleton } from "@packages/ui/components/skeleton";
 import { cn } from "@packages/ui/lib/utils";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { Activity, CheckCheck, GitBranch, Pause, Play, Tag, Target, Trash2 } from "lucide-react";
+import {
+   Activity,
+   CheckCheck,
+   GitBranch,
+   Pause,
+   Play,
+   Tag,
+   Target,
+   Trash2,
+} from "lucide-react";
 import { Suspense, useCallback, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { toast } from "sonner";
-import { orpc } from "@/integrations/orpc/client";
 import {
    ContextPanelAction,
    ContextPanelDivider,
    ContextPanelMeta,
 } from "@/features/context-panel/context-panel-info";
 import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
+import { orpc } from "@/integrations/orpc/client";
 import {
    type ExperimentStatus,
    useExperimentConfig,
@@ -138,7 +147,8 @@ function ExperimentBuilderEditContent({
    const canEdit = status === "draft" || status === "paused";
    const variantCount = experiment.variants?.length ?? 0;
    const isRunning = status === "running";
-   const canStart = (status === "draft" || status === "paused") && variantCount >= 2;
+   const canStart =
+      (status === "draft" || status === "paused") && variantCount >= 2;
 
    const updateMutation = useMutation(
       orpc.experiments.update.mutationOptions({
@@ -195,14 +205,21 @@ function ExperimentBuilderEditContent({
             <ContextPanelMeta
                icon={Tag}
                label="Tipo"
-               value={TARGET_TYPE_LABELS[experiment.targetType] ?? experiment.targetType}
+               value={
+                  TARGET_TYPE_LABELS[experiment.targetType] ??
+                  experiment.targetType
+               }
             />
             <ContextPanelMeta
                icon={Target}
                label="Meta"
                value={GOAL_LABELS[experiment.goal] ?? experiment.goal}
             />
-            <ContextPanelMeta icon={GitBranch} label="Variantes" value={variantCount} />
+            <ContextPanelMeta
+               icon={GitBranch}
+               label="Variantes"
+               value={variantCount}
+            />
             <ContextPanelDivider />
             {canStart && (
                <ContextPanelAction

--- a/apps/web/src/features/experiments/ui/experiment-builder.tsx
+++ b/apps/web/src/features/experiments/ui/experiment-builder.tsx
@@ -1,13 +1,26 @@
+import {
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelHeader,
+   ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
 import { Button } from "@packages/ui/components/button";
 import { createErrorFallback } from "@packages/ui/components/error-fallback";
 import { Skeleton } from "@packages/ui/components/skeleton";
 import { cn } from "@packages/ui/lib/utils";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useNavigate, useParams } from "@tanstack/react-router";
+import { CheckCheck, Pause, Play, Trash2 } from "lucide-react";
 import { Suspense, useCallback, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { toast } from "sonner";
 import { orpc } from "@/integrations/orpc/client";
+import {
+   ContextPanelAction,
+   ContextPanelDivider,
+   ContextPanelMeta,
+} from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import {
    type ExperimentStatus,
    useExperimentConfig,
@@ -16,6 +29,26 @@ import { ExperimentBuilderHeader } from "./experiment-builder-header";
 import { ExperimentConfigTab } from "./experiment-config-tab";
 import { ExperimentResultsTab } from "./experiment-results-tab";
 import { ExperimentVariantsTab } from "./experiment-variants-tab";
+
+const TARGET_TYPE_LABELS: Record<string, string> = {
+   content: "Conteúdo",
+   form: "Formulário",
+   cluster: "Cluster",
+};
+
+const GOAL_LABELS: Record<string, string> = {
+   conversion: "Conversão",
+   ctr: "Taxa de clique",
+   time_on_page: "Tempo na página",
+   form_submit: "Envio de formulário",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+   draft: "Rascunho",
+   running: "Em execução",
+   paused: "Pausado",
+   concluded: "Concluído",
+};
 
 const TABS = [
    { value: "config", label: "Configuração" },
@@ -104,6 +137,8 @@ function ExperimentBuilderEditContent({
    const status = experiment.status as ExperimentStatus;
    const canEdit = status === "draft" || status === "paused";
    const variantCount = experiment.variants?.length ?? 0;
+   const isRunning = status === "running";
+   const canStart = (status === "draft" || status === "paused") && variantCount >= 2;
 
    const updateMutation = useMutation(
       orpc.experiments.update.mutationOptions({
@@ -144,6 +179,57 @@ function ExperimentBuilderEditContent({
          },
          onError: (err) => toast.error(err.message ?? "Erro ao excluir"),
       }),
+   );
+
+   useContextPanelInfo(
+      <ContextPanel>
+         <ContextPanelHeader>
+            <ContextPanelTitle>{experiment.name}</ContextPanelTitle>
+         </ContextPanelHeader>
+         <ContextPanelContent>
+            <ContextPanelMeta
+               label="Status"
+               value={STATUS_LABELS[experiment.status] ?? experiment.status}
+            />
+            <ContextPanelMeta
+               label="Tipo"
+               value={TARGET_TYPE_LABELS[experiment.targetType] ?? experiment.targetType}
+            />
+            <ContextPanelMeta
+               label="Meta"
+               value={GOAL_LABELS[experiment.goal] ?? experiment.goal}
+            />
+            <ContextPanelMeta label="Variantes" value={variantCount} />
+            <ContextPanelDivider />
+            {canStart && (
+               <ContextPanelAction
+                  icon={Play}
+                  label="Iniciar"
+                  onClick={() => startMutation.mutate({ id: experimentId })}
+               />
+            )}
+            {isRunning && (
+               <ContextPanelAction
+                  icon={Pause}
+                  label="Pausar"
+                  onClick={() => pauseMutation.mutate({ id: experimentId })}
+               />
+            )}
+            {(isRunning || status === "paused") && (
+               <ContextPanelAction
+                  icon={CheckCheck}
+                  label="Concluir"
+                  onClick={() => concludeMutation.mutate({ id: experimentId })}
+               />
+            )}
+            <ContextPanelAction
+               icon={Trash2}
+               label="Excluir experimento"
+               onClick={() => removeMutation.mutate({ id: experimentId })}
+               variant="destructive"
+            />
+         </ContextPanelContent>
+      </ContextPanel>,
    );
 
    const handleSave = useCallback(() => {

--- a/apps/web/src/features/teco-chat/ui/context-picker.tsx
+++ b/apps/web/src/features/teco-chat/ui/context-picker.tsx
@@ -100,6 +100,7 @@ function ContextPickerInner({
             <div className="flex items-center gap-2 border-b px-3 py-2">
                <span className="text-muted-foreground">
                   <svg
+                     aria-hidden="true"
                      className="size-4"
                      fill="none"
                      stroke="currentColor"
@@ -111,6 +112,7 @@ function ContextPickerInner({
                   </svg>
                </span>
                <input
+                  // biome-ignore lint/a11y/noAutofocus: search input in popover should autofocus for UX
                   autoFocus
                   className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
                   onChange={(e) => setSearch(e.target.value)}

--- a/apps/web/src/features/teco-chat/ui/thread.tsx
+++ b/apps/web/src/features/teco-chat/ui/thread.tsx
@@ -95,7 +95,7 @@ export const Thread: FC<ThreadProps> = ({
          }}
       >
          <ThreadPrimitive.Viewport
-            className="aui-thread-viewport relative flex flex-1 flex-col overflow-y-auto scroll-smooth px-4 pt-4"
+            className="aui-thread-viewport relative flex flex-1 flex-col overflow-y-auto scroll-smooth "
             turnAnchor="top"
          >
             <AuiIf condition={(s) => s.thread.isEmpty}>
@@ -116,7 +116,7 @@ export const Thread: FC<ThreadProps> = ({
                }}
             />
 
-            <ThreadPrimitive.ViewportFooter className="aui-thread-viewport-footer sticky bottom-0 mx-auto mt-auto flex w-full max-w-(--thread-max-width) flex-col gap-4 overflow-visible rounded-t-3xl bg-transparent pb-4 md:pb-6">
+            <ThreadPrimitive.ViewportFooter className="aui-thread-viewport-footer sticky bottom-0 mx-auto mt-auto flex w-full max-w-(--thread-max-width) flex-col gap-4 overflow-visible rounded-t-3xl bg-transparent pb-4 ">
                <AuiIf condition={(s) => !s.thread.isEmpty}>
                   <ThreadScrollToBottom />
                   <AgentNetworkStatus />

--- a/apps/web/src/integrations/orpc/router/agent.ts
+++ b/apps/web/src/integrations/orpc/router/agent.ts
@@ -66,7 +66,7 @@ export const copilotStream = protectedProcedure
          contentId: z.string().optional(),
       }),
    )
-   .handler(async function*({ context, input }) {
+   .handler(async function* ({ context, input }) {
       const { userId, db, organizationId, posthog, teamId, headers } = context;
 
       await enforceCreditBudget(db, organizationId, "ai");
@@ -190,7 +190,7 @@ export const aiCommandStream = protectedProcedure
          language: z.string().optional(),
       }),
    )
-   .handler(async function*({ context, input }) {
+   .handler(async function* ({ context, input }) {
       const { userId, db, organizationId, posthog, teamId, headers } = context;
 
       await enforceCreditBudget(db, organizationId, "ai");

--- a/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
+++ b/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
@@ -79,8 +79,10 @@ export function useSidebarSection(section: SubSidebarSection) {
       return () => {
          sidebarNavStore.setState((state) => ({
             ...state,
-            activeSection: state.activeSection === section ? null : state.activeSection,
-            searchQuery: state.activeSection === section ? "" : state.searchQuery,
+            activeSection:
+               state.activeSection === section ? null : state.activeSection,
+            searchQuery:
+               state.activeSection === section ? "" : state.searchQuery,
          }));
       };
    }, [section]);

--- a/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
+++ b/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
 import { Store, useStore } from "@tanstack/react-store";
+import { useEffect } from "react";
 
 export type SubSidebarSection = "dashboards" | "insights" | "data-management";
 
@@ -76,6 +76,12 @@ export function useSidebarNav() {
 export function useSidebarSection(section: SubSidebarSection) {
    useEffect(() => {
       setActiveSection(section);
-      return () => setActiveSection(null);
+      return () => {
+         sidebarNavStore.setState((state) => ({
+            ...state,
+            activeSection: state.activeSection === section ? null : state.activeSection,
+            searchQuery: state.activeSection === section ? "" : state.searchQuery,
+         }));
+      };
    }, [section]);
 }

--- a/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
+++ b/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
@@ -24,11 +24,13 @@ function savePinnedItems(items: string[]) {
 
 interface SidebarNavState {
    activeSection: SubSidebarSection | null;
+   searchQuery: string;
    pinnedItems: string[];
 }
 
 const initialState: SidebarNavState = {
    activeSection: null,
+   searchQuery: "",
    pinnedItems: loadPinnedItems(),
 };
 
@@ -38,6 +40,14 @@ export function setActiveSection(section: SubSidebarSection | null) {
    sidebarNavStore.setState((state) => ({
       ...state,
       activeSection: section,
+      searchQuery: "",
+   }));
+}
+
+export function setSearchQuery(query: string) {
+   sidebarNavStore.setState((state) => ({
+      ...state,
+      searchQuery: query,
    }));
 }
 
@@ -56,6 +66,8 @@ export function useSidebarNav() {
 
    return {
       activeSection: state.activeSection,
+      searchQuery: state.searchQuery,
       pinnedItems: state.pinnedItems,
+      setSearchQuery,
    };
 }

--- a/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
+++ b/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Store, useStore } from "@tanstack/react-store";
 
 export type SubSidebarSection = "dashboards" | "insights" | "data-management";
@@ -70,4 +71,11 @@ export function useSidebarNav() {
       pinnedItems: state.pinnedItems,
       setSearchQuery,
    };
+}
+
+export function useSidebarSection(section: SubSidebarSection) {
+   useEffect(() => {
+      setActiveSection(section);
+      return () => setActiveSection(null);
+   }, [section]);
 }

--- a/apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
+++ b/apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
@@ -21,7 +21,6 @@ import { useLastOrganization } from "@/hooks/use-last-organization";
 import { useSafeLocalStorage } from "@/hooks/use-local-storage";
 import { authClient } from "@/integrations/better-auth/auth-client";
 import { orpc } from "@/integrations/orpc/client";
-import { setActiveSection } from "../hooks/use-sidebar-nav";
 import { AppSidebar } from "./app-sidebar";
 import { SidebarSubPanel } from "./sidebar-sub-panel";
 
@@ -129,18 +128,6 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
       activeOrganization?.slug,
    ]);
 
-   useEffect(() => {
-      if (pathname.includes("/analytics/dashboards")) {
-         setActiveSection("dashboards");
-      } else if (pathname.includes("/analytics/insights")) {
-         setActiveSection("insights");
-      } else if (pathname.includes("/analytics/data-management")) {
-         setActiveSection("data-management");
-      } else {
-         setActiveSection(null);
-      }
-   }, [pathname]);
-
    return (
       <EarlyAccessProvider>
          <SidebarManagerProvider>
@@ -169,8 +156,8 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
                            isEditorPage || isChatPage
                               ? "overflow-hidden p-0"
                               : isSettingsPage
-                                 ? "overflow-hidden p-4"
-                                 : "overflow-y-auto p-4",
+                                ? "overflow-hidden p-4"
+                                : "overflow-y-auto p-4",
                         )}
                      >
                         {children}

--- a/apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
+++ b/apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
@@ -154,10 +154,10 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
                         className={cn(
                            "relative flex-1",
                            isEditorPage || isChatPage
-                              ? "overflow-hidden p-0"
+                              ? "overflow-hidden "
                               : isSettingsPage
-                                ? "overflow-hidden p-4"
-                                : "overflow-y-auto p-4",
+                                 ? "overflow-hidden p-4"
+                                 : "overflow-y-auto p-4",
                         )}
                      >
                         {children}

--- a/apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
+++ b/apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
@@ -156,8 +156,8 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
                            isEditorPage || isChatPage
                               ? "overflow-hidden "
                               : isSettingsPage
-                                 ? "overflow-hidden p-4"
-                                 : "overflow-y-auto p-4",
+                                ? "overflow-hidden p-4"
+                                : "overflow-y-auto p-4",
                         )}
                      >
                         {children}

--- a/apps/web/src/layout/dashboard/ui/sidebar-scope-switcher.tsx
+++ b/apps/web/src/layout/dashboard/ui/sidebar-scope-switcher.tsx
@@ -213,9 +213,9 @@ function SidebarScopeSwitcherContent() {
             if (pathname.startsWith(`${prefix}/`)) {
                nextPath = params.teamSlug
                   ? pathname.replace(
-                     `${prefix}/${params.teamSlug}`,
-                     `${prefix}/${teamParam}`,
-                  )
+                       `${prefix}/${params.teamSlug}`,
+                       `${prefix}/${teamParam}`,
+                    )
                   : `/${currentSlug}/${teamParam}${pathname.slice(prefix.length)}`;
             }
 
@@ -403,7 +403,7 @@ function SidebarScopeSwitcherContent() {
                            <Plus className="size-4" />
                            <span>
                               {projectLimit !== null &&
-                                 projectLimit !== Number.POSITIVE_INFINITY
+                              projectLimit !== Number.POSITIVE_INFINITY
                                  ? `Novo projeto (${projectCount}/${projectLimit})`
                                  : "Novo projeto"}
                            </span>

--- a/apps/web/src/layout/dashboard/ui/sidebar-sub-panel.tsx
+++ b/apps/web/src/layout/dashboard/ui/sidebar-sub-panel.tsx
@@ -53,7 +53,7 @@ function SubPanelSidebar({
    const mainSidebar = manager.use("main");
    const panelLeft =
       mainSidebar?.state === "collapsed"
-         ? "calc(var(--sidebar-width-icon) - 1px)"
+         ? "calc(var(--sidebar-width-icon) + 1rem)"
          : "calc(var(--sidebar-width) - 1px)";
 
    const handleItemClick = useCallback(() => {

--- a/apps/web/src/layout/dashboard/ui/sidebar-sub-panel.tsx
+++ b/apps/web/src/layout/dashboard/ui/sidebar-sub-panel.tsx
@@ -7,7 +7,7 @@ import {
 } from "@packages/ui/components/sidebar";
 import { cn } from "@packages/ui/lib/utils";
 import { Search, X } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 import {
    type SubSidebarSection,
    setActiveSection,
@@ -25,8 +25,16 @@ const SECTION_TITLES: Record<string, string> = {
 export function SidebarSubPanel() {
    const { activeSection } = useSidebarNav();
 
+   const handleOpenChange = useCallback((open: boolean) => {
+      if (!open) setActiveSection(null);
+   }, []);
+
    return (
-      <SidebarProvider className="min-h-0" defaultOpen={false}>
+      <SidebarProvider
+         className="min-h-0"
+         onOpenChange={handleOpenChange}
+         open={activeSection !== null}
+      >
          <SidebarManager name="sub-panel">
             <SubPanelSidebar activeSection={activeSection} />
          </SidebarManager>
@@ -39,31 +47,18 @@ function SubPanelSidebar({
 }: {
    activeSection: SubSidebarSection | null;
 }) {
-   const { open, setOpen } = useSidebar();
+   const { open } = useSidebar();
+   const { searchQuery, setSearchQuery } = useSidebarNav();
    const manager = useSidebarManager();
    const mainSidebar = manager.use("main");
    const panelLeft =
       mainSidebar?.state === "collapsed"
          ? "calc(var(--sidebar-width-icon) - 1px)"
          : "calc(var(--sidebar-width) - 1px)";
-   const [searchQuery, setSearchQuery] = useState("");
 
    const handleItemClick = useCallback(() => {
-      setOpen(false);
       setActiveSection(null);
-   }, [setOpen]);
-
-   // Reset search when section changes
-   useEffect(() => {
-      setSearchQuery("");
-   }, [activeSection]);
-
-   // Close when no active section
-   useEffect(() => {
-      if (!activeSection && open) {
-         setOpen(false);
-      }
-   }, [activeSection, open, setOpen]);
+   }, []);
 
    if (!open || !activeSection) return null;
 
@@ -72,7 +67,7 @@ function SubPanelSidebar({
          <button
             aria-label="Fechar painel"
             className="fixed inset-y-0 right-0 z-[900] bg-background/35 backdrop-blur-md backdrop-saturate-150"
-            onClick={() => setOpen(false)}
+            onClick={() => setActiveSection(null)}
             style={{ left: `calc(${panelLeft} + 280px)` }}
             type="button"
          />
@@ -101,7 +96,7 @@ function SubPanelSidebar({
                      <button
                         aria-label="Fechar painel"
                         className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-                        onClick={() => setOpen(false)}
+                        onClick={() => setActiveSection(null)}
                         type="button"
                      >
                         <X className="size-4" />

--- a/apps/web/src/layout/dashboard/ui/theme-switcher.tsx
+++ b/apps/web/src/layout/dashboard/ui/theme-switcher.tsx
@@ -6,6 +6,7 @@ import {
 } from "@packages/ui/components/tooltip";
 import { useTheme } from "@packages/ui/lib/theme-provider";
 import { cn } from "@packages/ui/lib/utils";
+import { ClientOnly } from "@tanstack/react-router";
 import { Monitor, Moon, Sun } from "lucide-react";
 import { motion } from "motion/react";
 import { useCallback } from "react";
@@ -46,51 +47,56 @@ export const ThemeSwitcher = ({ className }: ThemeSwitcherProps) => {
    );
 
    return (
-      <TooltipProvider>
-         <div
-            className={cn(
-               "relative isolate flex h-8 rounded-full bg-background p-1 ring-1 ring-border",
-               className,
-            )}
-         >
-            {themes.map(({ key, icon: Icon, label }) => {
-               const isActive = theme === key;
+      <ClientOnly fallback={null}>
+         <TooltipProvider>
+            <div
+               className={cn(
+                  "relative isolate flex h-8 rounded-full bg-background p-1 ring-1 ring-border",
+                  className,
+               )}
+            >
+               {themes.map(({ key, icon: Icon, label }) => {
+                  const isActive = theme === key;
 
-               return (
-                  <Tooltip key={key}>
-                     <TooltipTrigger asChild>
-                        <button
-                           aria-label={label}
-                           className="relative h-6 w-6 rounded-full"
-                           onClick={() =>
-                              handleThemeClick(
-                                 key as "light" | "dark" | "system",
-                              )
-                           }
-                           type="button"
-                        >
-                           {isActive && (
-                              <motion.div
-                                 className="absolute inset-0 rounded-full bg-muted"
-                                 layoutId="activeTheme"
-                                 transition={{ duration: 0.5, type: "spring" }}
-                              />
-                           )}
-                           <Icon
-                              className={cn(
-                                 "relative z-10 m-auto h-4 w-4",
-                                 isActive
-                                    ? "text-foreground"
-                                    : "text-muted-foreground",
+                  return (
+                     <Tooltip key={key}>
+                        <TooltipTrigger asChild>
+                           <button
+                              aria-label={label}
+                              className="relative h-6 w-6 rounded-full"
+                              onClick={() =>
+                                 handleThemeClick(
+                                    key as "light" | "dark" | "system",
+                                 )
+                              }
+                              type="button"
+                           >
+                              {isActive && (
+                                 <motion.div
+                                    className="absolute inset-0 rounded-full bg-muted"
+                                    layoutId="activeTheme"
+                                    transition={{
+                                       duration: 0.5,
+                                       type: "spring",
+                                    }}
+                                 />
                               )}
-                           />
-                        </button>
-                     </TooltipTrigger>
-                     <TooltipContent>{label}</TooltipContent>
-                  </Tooltip>
-               );
-            })}
-         </div>
-      </TooltipProvider>
+                              <Icon
+                                 className={cn(
+                                    "relative z-10 m-auto h-4 w-4",
+                                    isActive
+                                       ? "text-foreground"
+                                       : "text-muted-foreground",
+                                 )}
+                              />
+                           </button>
+                        </TooltipTrigger>
+                        <TooltipContent>{label}</TooltipContent>
+                     </Tooltip>
+                  );
+               })}
+            </div>
+         </TooltipProvider>
+      </ClientOnly>
    );
 };

--- a/apps/web/src/layout/dashboard/ui/theme-switcher.tsx
+++ b/apps/web/src/layout/dashboard/ui/theme-switcher.tsx
@@ -8,7 +8,7 @@ import { useTheme } from "@packages/ui/lib/theme-provider";
 import { cn } from "@packages/ui/lib/utils";
 import { Monitor, Moon, Sun } from "lucide-react";
 import { motion } from "motion/react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 
 export type ThemeSwitcherProps = {
    className?: string;
@@ -34,7 +34,6 @@ export const ThemeSwitcher = ({ className }: ThemeSwitcherProps) => {
    ];
 
    const { theme, setTheme } = useTheme();
-   const [mounted, setMounted] = useState(false);
 
    const handleThemeClick = useCallback(
       (themeKey: "light" | "dark" | "system") => {
@@ -45,15 +44,6 @@ export const ThemeSwitcher = ({ className }: ThemeSwitcherProps) => {
       },
       [setTheme],
    );
-
-   // Prevent hydration mismatch
-   useEffect(() => {
-      setMounted(true);
-   }, []);
-
-   if (!mounted) {
-      return null;
-   }
 
    return (
       <TooltipProvider>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/$dashboardId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/$dashboardId.tsx
@@ -4,6 +4,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Suspense } from "react";
 import { DashboardView } from "@/features/analytics/ui/dashboard-view";
 import { orpc } from "@/integrations/orpc/client";
+import { useSidebarSection } from "@/layout/dashboard/hooks/use-sidebar-nav";
 
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/$dashboardId",
@@ -41,6 +42,7 @@ function DashboardViewPageContent() {
 }
 
 function DashboardViewPage() {
+   useSidebarSection("dashboards");
    return (
       <Suspense fallback={<DashboardSkeleton />}>
          <DashboardViewPageContent />

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/index.tsx
@@ -1,4 +1,10 @@
 import { Button } from "@packages/ui/components/button";
+import {
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelHeader,
+   ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
 import { Skeleton } from "@packages/ui/components/skeleton";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
@@ -6,12 +12,6 @@ import { LayoutDashboard, Plus } from "lucide-react";
 import { Suspense } from "react";
 import { PageHeader } from "@/components/page-header";
 import { DashboardListCard } from "@/features/analytics/ui/dashboard-list-card";
-import {
-	ContextPanel,
-	ContextPanelContent,
-	ContextPanelHeader,
-	ContextPanelTitle,
-} from "@packages/ui/components/context-panel";
 import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
 import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import { orpc } from "@/integrations/orpc/client";
@@ -82,21 +82,21 @@ function DashboardsList() {
 function DashboardsPage() {
    useSidebarSection("dashboards");
    useContextPanelInfo(
-		<ContextPanel>
-			<ContextPanelHeader>
-				<ContextPanelTitle>Ações</ContextPanelTitle>
-			</ContextPanelHeader>
-			<ContextPanelContent>
-				<ContextPanelAction
-					icon={Plus}
-					label="Novo dashboard"
-					onClick={() => {
-						// TODO: Wire to create dashboard action
-					}}
-				/>
-			</ContextPanelContent>
-		</ContextPanel>,
-	);
+      <ContextPanel>
+         <ContextPanelHeader>
+            <ContextPanelTitle>Ações</ContextPanelTitle>
+         </ContextPanelHeader>
+         <ContextPanelContent>
+            <ContextPanelAction
+               icon={Plus}
+               label="Novo dashboard"
+               onClick={() => {
+                  // TODO: Wire to create dashboard action
+               }}
+            />
+         </ContextPanelContent>
+      </ContextPanel>,
+   );
 
    return (
       <main className="flex flex-col gap-4">

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/index.tsx
@@ -15,6 +15,7 @@ import {
 import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
 import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import { orpc } from "@/integrations/orpc/client";
+import { useSidebarSection } from "@/layout/dashboard/hooks/use-sidebar-nav";
 
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/",
@@ -79,6 +80,7 @@ function DashboardsList() {
 }
 
 function DashboardsPage() {
+   useSidebarSection("dashboards");
    useContextPanelInfo(
 		<ContextPanel>
 			<ContextPanelHeader>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/index.tsx
@@ -7,9 +7,12 @@ import { Suspense } from "react";
 import { PageHeader } from "@/components/page-header";
 import { DashboardListCard } from "@/features/analytics/ui/dashboard-list-card";
 import {
-   ContextPanelAction,
-   ContextPanelSection,
-} from "@/features/context-panel/context-panel-info";
+	ContextPanel,
+	ContextPanelContent,
+	ContextPanelHeader,
+	ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
+import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
 import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import { orpc } from "@/integrations/orpc/client";
 
@@ -77,16 +80,21 @@ function DashboardsList() {
 
 function DashboardsPage() {
    useContextPanelInfo(
-      <ContextPanelSection title="Ações">
-         <ContextPanelAction
-            icon={Plus}
-            label="Novo dashboard"
-            onClick={() => {
-               // TODO: Wire to create dashboard action
-            }}
-         />
-      </ContextPanelSection>,
-   );
+		<ContextPanel>
+			<ContextPanelHeader>
+				<ContextPanelTitle>Ações</ContextPanelTitle>
+			</ContextPanelHeader>
+			<ContextPanelContent>
+				<ContextPanelAction
+					icon={Plus}
+					label="Novo dashboard"
+					onClick={() => {
+						// TODO: Wire to create dashboard action
+					}}
+				/>
+			</ContextPanelContent>
+		</ContextPanel>,
+	);
 
    return (
       <main className="flex flex-col gap-4">

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
-import { DataManagementLayout } from "@/layout/dashboard/ui/data-management-layout";
 import { useSidebarSection } from "@/layout/dashboard/hooks/use-sidebar-nav";
+import { DataManagementLayout } from "@/layout/dashboard/ui/data-management-layout";
 
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management",

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 import { DataManagementLayout } from "@/layout/dashboard/ui/data-management-layout";
+import { useSidebarSection } from "@/layout/dashboard/hooks/use-sidebar-nav";
 
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management",
@@ -8,6 +9,7 @@ export const Route = createFileRoute(
 });
 
 function DataManagementLayoutRoute() {
+   useSidebarSection("data-management");
    return (
       <DataManagementLayout>
          <Outlet />

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId.tsx
@@ -12,6 +12,7 @@ import {
 import { InsightBuilder } from "@/features/analytics/ui/insight-builder";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { orpc } from "@/integrations/orpc/client";
+import { useSidebarSection } from "@/layout/dashboard/hooks/use-sidebar-nav";
 
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId",
@@ -20,6 +21,7 @@ export const Route = createFileRoute(
 });
 
 function EditInsightPage() {
+   useSidebarSection("insights");
    const { insightId, slug, teamSlug } = Route.useParams();
    const navigate = useNavigate();
    const queryClient = useQueryClient();

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId.tsx
@@ -14,7 +14,7 @@ import {
    ContextPanelMeta,
 } from "@/features/context-panel/context-panel-info";
 import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
-import { AlertCircle, Copy, RefreshCw, Trash2 } from "lucide-react";
+import { AlertCircle, Clock, Copy, RefreshCw, Tag, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -191,10 +191,12 @@ function EditInsightPage() {
             </ContextPanelHeader>
             <ContextPanelContent>
                <ContextPanelMeta
+                  icon={Tag}
                   label="Tipo"
                   value={TYPE_LABELS[insight.type] ?? insight.type}
                />
                <ContextPanelMeta
+                  icon={Clock}
                   label="Calculado"
                   value={
                      insight.lastComputedAt

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId.tsx
@@ -2,7 +2,19 @@ import type { InsightConfig } from "@packages/analytics/types";
 import { Skeleton } from "@packages/ui/components/skeleton";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { AlertCircle } from "lucide-react";
+import {
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelHeader,
+   ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
+import {
+   ContextPanelAction,
+   ContextPanelDivider,
+   ContextPanelMeta,
+} from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
+import { AlertCircle, Copy, RefreshCw, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -164,6 +176,57 @@ function EditInsightPage() {
          }).queryKey,
       });
    }, [queryClient, insight?.config, insightId]);
+
+   const TYPE_LABELS: Record<string, string> = {
+      trends: "Tendências",
+      funnels: "Funis",
+      retention: "Retenção",
+   };
+
+   useContextPanelInfo(
+      insight ? (
+         <ContextPanel>
+            <ContextPanelHeader>
+               <ContextPanelTitle>{insightName || insight.name}</ContextPanelTitle>
+            </ContextPanelHeader>
+            <ContextPanelContent>
+               <ContextPanelMeta
+                  label="Tipo"
+                  value={TYPE_LABELS[insight.type] ?? insight.type}
+               />
+               <ContextPanelMeta
+                  label="Calculado"
+                  value={
+                     insight.lastComputedAt
+                        ? new Date(insight.lastComputedAt).toLocaleDateString(
+                             "pt-BR",
+                             { day: "2-digit", month: "short", year: "numeric" },
+                          )
+                        : "—"
+                  }
+               />
+               <ContextPanelDivider />
+               <ContextPanelAction
+                  icon={Copy}
+                  label="Duplicar insight"
+                  onClick={handleDuplicate}
+               />
+               <ContextPanelAction
+                  icon={RefreshCw}
+                  label="Atualizar resultados"
+                  onClick={handleRefresh}
+               />
+               <ContextPanelDivider />
+               <ContextPanelAction
+                  icon={Trash2}
+                  label="Excluir insight"
+                  onClick={handleDelete}
+                  variant="destructive"
+               />
+            </ContextPanelContent>
+         </ContextPanel>
+      ) : null,
+   );
 
    if (isLoading) {
       return (

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId.tsx
@@ -1,19 +1,13 @@
 import type { InsightConfig } from "@packages/analytics/types";
-import { Skeleton } from "@packages/ui/components/skeleton";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
    ContextPanel,
    ContextPanelContent,
    ContextPanelHeader,
    ContextPanelTitle,
 } from "@packages/ui/components/context-panel";
-import {
-   ContextPanelAction,
-   ContextPanelDivider,
-   ContextPanelMeta,
-} from "@/features/context-panel/context-panel-info";
-import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
+import { Skeleton } from "@packages/ui/components/skeleton";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { AlertCircle, Clock, Copy, RefreshCw, Tag, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -22,6 +16,12 @@ import {
    useInsightConfig,
 } from "@/features/analytics/hooks/use-insight-config";
 import { InsightBuilder } from "@/features/analytics/ui/insight-builder";
+import {
+   ContextPanelAction,
+   ContextPanelDivider,
+   ContextPanelMeta,
+} from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { orpc } from "@/integrations/orpc/client";
 import { useSidebarSection } from "@/layout/dashboard/hooks/use-sidebar-nav";
@@ -187,7 +187,9 @@ function EditInsightPage() {
       insight ? (
          <ContextPanel>
             <ContextPanelHeader>
-               <ContextPanelTitle>{insightName || insight.name}</ContextPanelTitle>
+               <ContextPanelTitle>
+                  {insightName || insight.name}
+               </ContextPanelTitle>
             </ContextPanelHeader>
             <ContextPanelContent>
                <ContextPanelMeta
@@ -202,7 +204,11 @@ function EditInsightPage() {
                      insight.lastComputedAt
                         ? new Date(insight.lastComputedAt).toLocaleDateString(
                              "pt-BR",
-                             { day: "2-digit", month: "short", year: "numeric" },
+                             {
+                                day: "2-digit",
+                                month: "short",
+                                year: "numeric",
+                             },
                           )
                         : "—"
                   }

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/index.tsx
@@ -25,6 +25,7 @@ import { toast } from "sonner";
 import { PageHeader } from "@/components/page-header";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { orpc } from "@/integrations/orpc/client";
+import { useSidebarSection } from "@/layout/dashboard/hooks/use-sidebar-nav";
 
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/",
@@ -111,6 +112,7 @@ function EmptyState({ slug, teamSlug }: { slug: string; teamSlug: string }) {
 // ---------------------------------------------------------------------------
 
 function InsightsListPage() {
+   useSidebarSection("insights");
    const navigate = useNavigate();
    const { slug, teamSlug } = Route.useParams();
    const queryClient = useQueryClient();

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/index.tsx
@@ -1,5 +1,11 @@
 import { Badge } from "@packages/ui/components/badge";
 import { Button } from "@packages/ui/components/button";
+import {
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelHeader,
+   ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
 import { Skeleton } from "@packages/ui/components/skeleton";
 import {
    Table,
@@ -23,6 +29,8 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/page-header";
+import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { orpc } from "@/integrations/orpc/client";
 import { useSidebarSection } from "@/layout/dashboard/hooks/use-sidebar-nav";
@@ -117,6 +125,26 @@ function InsightsListPage() {
    const { slug, teamSlug } = Route.useParams();
    const queryClient = useQueryClient();
    const { openAlertDialog } = useAlertDialog();
+
+   useContextPanelInfo(
+      <ContextPanel>
+         <ContextPanelHeader>
+            <ContextPanelTitle>Ações</ContextPanelTitle>
+         </ContextPanelHeader>
+         <ContextPanelContent>
+            <ContextPanelAction
+               icon={Plus}
+               label="Novo insight"
+               onClick={() =>
+                  navigate({
+                     to: "/$slug/$teamSlug/analytics/insights/new",
+                     params: { slug, teamSlug },
+                  })
+               }
+            />
+         </ContextPanelContent>
+      </ContextPanel>,
+   );
 
    const {
       data: insights,

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/new.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/new.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import { useInsightConfig } from "@/features/analytics/hooks/use-insight-config";
 import { InsightBuilder } from "@/features/analytics/ui/insight-builder";
 import { orpc } from "@/integrations/orpc/client";
+import { useSidebarSection } from "@/layout/dashboard/hooks/use-sidebar-nav";
 
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/new",
@@ -18,6 +19,7 @@ export const Route = createFileRoute(
 });
 
 function NewInsightPage() {
+   useSidebarSection("insights");
    const navigate = useNavigate();
    const { slug, teamSlug } = useParams({
       from: "/_authenticated/$slug/$teamSlug/_dashboard",

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat.tsx
@@ -8,9 +8,9 @@ import {
 } from "@tanstack/react-router";
 import { MessageSquarePlusIcon } from "lucide-react";
 import { useEffect } from "react";
+import { closeContextPanel } from "@/features/context-panel/use-context-panel";
 import { useTecoRuntime } from "@/features/teco-chat/hooks/use-teco-runtime";
 import { ThreadList } from "@/features/teco-chat/ui/thread-list";
-import { closeContextPanel } from "@/features/context-panel/use-context-panel";
 import { useActiveTeam } from "@/hooks/use-active-team";
 
 export const Route = createFileRoute(

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/$threadId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/$threadId.tsx
@@ -71,11 +71,11 @@ function ChatThreadPage() {
    return (
       <AssistantRuntimeProvider runtime={runtime}>
          <Thread
+            onModeChange={setMode}
             quickSuggestions={QUICK_SUGGESTIONS}
             welcomeIconUrl="/mascot.svg"
             welcomeSubtitle="Seu assistente de conteúdo com IA."
             welcomeTitle="Como posso te ajudar?"
-            onModeChange={setMode}
          />
       </AssistantRuntimeProvider>
    );

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/index.tsx
@@ -86,11 +86,11 @@ function ChatIndexPageContent({ teamId }: { teamId: string }) {
    return (
       <AssistantRuntimeProvider runtime={runtime}>
          <Thread
+            onModeChange={setMode}
             quickSuggestions={QUICK_SUGGESTIONS}
             welcomeIconUrl="/mascot.svg"
             welcomeSubtitle="Seu assistente de conteúdo com IA."
             welcomeTitle="Como posso te ajudar?"
-            onModeChange={setMode}
          />
       </AssistantRuntimeProvider>
    );

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/clusters/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/clusters/index.tsx
@@ -10,9 +10,9 @@ import { Plus } from "lucide-react";
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { PageHeader } from "@/components/page-header";
+import { ClustersListSection } from "@/features/clusters/ui/clusters-list-section";
 import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
 import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
-import { ClustersListSection } from "@/features/clusters/ui/clusters-list-section";
 
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/clusters/",

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/clusters/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/clusters/index.tsx
@@ -1,9 +1,17 @@
 import { Button } from "@packages/ui/components/button";
+import {
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelHeader,
+   ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Plus } from "lucide-react";
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { PageHeader } from "@/components/page-header";
+import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import { ClustersListSection } from "@/features/clusters/ui/clusters-list-section";
 
 export const Route = createFileRoute(
@@ -15,6 +23,26 @@ export const Route = createFileRoute(
 function ClustersPage() {
    const navigate = useNavigate();
    const { slug, teamSlug } = Route.useParams();
+
+   useContextPanelInfo(
+      <ContextPanel>
+         <ContextPanelHeader>
+            <ContextPanelTitle>Ações</ContextPanelTitle>
+         </ContextPanelHeader>
+         <ContextPanelContent>
+            <ContextPanelAction
+               icon={Plus}
+               label="Novo cluster"
+               onClick={() =>
+                  navigate({
+                     to: "/$slug/$teamSlug/clusters/new",
+                     params: { slug, teamSlug },
+                  })
+               }
+            />
+         </ContextPanelContent>
+      </ContextPanel>,
+   );
 
    return (
       <div className="space-y-6 p-6">

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/experiments/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/experiments/index.tsx
@@ -1,9 +1,18 @@
 import { createErrorFallback } from "@packages/ui/components/error-fallback";
 import { Skeleton } from "@packages/ui/components/skeleton";
-import { createFileRoute } from "@tanstack/react-router";
+import {
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelHeader,
+   ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Plus } from "lucide-react";
 import { Suspense } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import { PageHeader } from "@/components/page-header";
+import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import { ExperimentsListSection } from "@/features/experiments/ui/experiments-list-section";
 
 export const Route = createFileRoute(
@@ -33,6 +42,29 @@ function ExperimentsPageSkeleton() {
 }
 
 function ExperimentsPageContent() {
+   const navigate = useNavigate();
+   const { slug, teamSlug } = Route.useParams();
+
+   useContextPanelInfo(
+      <ContextPanel>
+         <ContextPanelHeader>
+            <ContextPanelTitle>Ações</ContextPanelTitle>
+         </ContextPanelHeader>
+         <ContextPanelContent>
+            <ContextPanelAction
+               icon={Plus}
+               label="Novo experimento"
+               onClick={() =>
+                  navigate({
+                     to: "/$slug/$teamSlug/experiments/new",
+                     params: { slug, teamSlug },
+                  })
+               }
+            />
+         </ContextPanelContent>
+      </ContextPanel>,
+   );
+
    return (
       <main className="flex flex-col gap-4">
          <PageHeader

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/experiments/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/experiments/index.tsx
@@ -1,11 +1,11 @@
-import { createErrorFallback } from "@packages/ui/components/error-fallback";
-import { Skeleton } from "@packages/ui/components/skeleton";
 import {
    ContextPanel,
    ContextPanelContent,
    ContextPanelHeader,
    ContextPanelTitle,
 } from "@packages/ui/components/context-panel";
+import { createErrorFallback } from "@packages/ui/components/error-fallback";
+import { Skeleton } from "@packages/ui/components/skeleton";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Plus } from "lucide-react";
 import { Suspense } from "react";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/forms/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/forms/index.tsx
@@ -1,4 +1,10 @@
 import { Button } from "@packages/ui/components/button";
+import {
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelHeader,
+   ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
 import { createErrorFallback } from "@packages/ui/components/error-fallback";
 import { Skeleton } from "@packages/ui/components/skeleton";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
@@ -6,12 +12,6 @@ import { Plus } from "lucide-react";
 import { Suspense } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import { PageHeader } from "@/components/page-header";
-import {
-	ContextPanel,
-	ContextPanelContent,
-	ContextPanelHeader,
-	ContextPanelTitle,
-} from "@packages/ui/components/context-panel";
 import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
 import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import { FormsList } from "@/features/forms/ui/forms-list";
@@ -47,24 +47,24 @@ function FormsPage() {
    const navigate = useNavigate();
 
    useContextPanelInfo(
-		<ContextPanel>
-			<ContextPanelHeader>
-				<ContextPanelTitle>Ações</ContextPanelTitle>
-			</ContextPanelHeader>
-			<ContextPanelContent>
-				<ContextPanelAction
-					icon={Plus}
-					label="Novo formulário"
-					onClick={() =>
-						navigate({
-							to: "/$slug/$teamSlug/forms/$formId",
-							params: { slug, teamSlug, formId: "new" },
-						})
-					}
-				/>
-			</ContextPanelContent>
-		</ContextPanel>,
-	);
+      <ContextPanel>
+         <ContextPanelHeader>
+            <ContextPanelTitle>Ações</ContextPanelTitle>
+         </ContextPanelHeader>
+         <ContextPanelContent>
+            <ContextPanelAction
+               icon={Plus}
+               label="Novo formulário"
+               onClick={() =>
+                  navigate({
+                     to: "/$slug/$teamSlug/forms/$formId",
+                     params: { slug, teamSlug, formId: "new" },
+                  })
+               }
+            />
+         </ContextPanelContent>
+      </ContextPanel>,
+   );
 
    return (
       <main className="flex flex-col gap-4">

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/forms/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/forms/index.tsx
@@ -7,9 +7,12 @@ import { Suspense } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import { PageHeader } from "@/components/page-header";
 import {
-   ContextPanelAction,
-   ContextPanelSection,
-} from "@/features/context-panel/context-panel-info";
+	ContextPanel,
+	ContextPanelContent,
+	ContextPanelHeader,
+	ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
+import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
 import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import { FormsList } from "@/features/forms/ui/forms-list";
 
@@ -44,19 +47,24 @@ function FormsPage() {
    const navigate = useNavigate();
 
    useContextPanelInfo(
-      <ContextPanelSection title="Ações">
-         <ContextPanelAction
-            icon={Plus}
-            label="Novo formulário"
-            onClick={() =>
-               navigate({
-                  to: "/$slug/$teamSlug/forms/$formId",
-                  params: { slug, teamSlug, formId: "new" },
-               })
-            }
-         />
-      </ContextPanelSection>,
-   );
+		<ContextPanel>
+			<ContextPanelHeader>
+				<ContextPanelTitle>Ações</ContextPanelTitle>
+			</ContextPanelHeader>
+			<ContextPanelContent>
+				<ContextPanelAction
+					icon={Plus}
+					label="Novo formulário"
+					onClick={() =>
+						navigate({
+							to: "/$slug/$teamSlug/forms/$formId",
+							params: { slug, teamSlug, formId: "new" },
+						})
+					}
+				/>
+			</ContextPanelContent>
+		</ContextPanel>,
+	);
 
    return (
       <main className="flex flex-col gap-4">

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/writers/$writerId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/writers/$writerId.tsx
@@ -7,7 +7,7 @@ import {
 import { Skeleton } from "@packages/ui/components/skeleton";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { AlertCircle, Trash2 } from "lucide-react";
+import { AlertCircle, FileText, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -124,7 +124,7 @@ function EditWriterPage() {
                <ContextPanelTitle>{writer.personaConfig.metadata.name}</ContextPanelTitle>
             </ContextPanelHeader>
             <ContextPanelContent>
-               <ContextPanelMeta label="Conteúdos" value={writer.contentCount ?? 0} />
+               <ContextPanelMeta icon={FileText} label="Conteúdos" value={writer.contentCount ?? 0} />
                <ContextPanelDivider />
                <ContextPanelAction
                   icon={Trash2}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/writers/$writerId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/writers/$writerId.tsx
@@ -1,9 +1,21 @@
+import {
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelHeader,
+   ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
 import { Skeleton } from "@packages/ui/components/skeleton";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
+import {
+   ContextPanelAction,
+   ContextPanelDivider,
+   ContextPanelMeta,
+} from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import { WriterBuilder } from "@/features/writers/ui/writer-builder";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { orpc } from "@/integrations/orpc/client";
@@ -104,6 +116,26 @@ function EditWriterPage() {
          onAction: () => deleteMutation.mutate({ id: writerId }),
       });
    }, [writerId, name, deleteMutation, openAlertDialog]);
+
+   useContextPanelInfo(
+      writer ? (
+         <ContextPanel>
+            <ContextPanelHeader>
+               <ContextPanelTitle>{writer.personaConfig.metadata.name}</ContextPanelTitle>
+            </ContextPanelHeader>
+            <ContextPanelContent>
+               <ContextPanelMeta label="Conteúdos" value={writer.contentCount ?? 0} />
+               <ContextPanelDivider />
+               <ContextPanelAction
+                  icon={Trash2}
+                  label="Excluir escritor"
+                  onClick={handleDelete}
+                  variant="destructive"
+               />
+            </ContextPanelContent>
+         </ContextPanel>
+      ) : null,
+   );
 
    if (isLoading) {
       return (

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/writers/$writerId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/writers/$writerId.tsx
@@ -121,10 +121,16 @@ function EditWriterPage() {
       writer ? (
          <ContextPanel>
             <ContextPanelHeader>
-               <ContextPanelTitle>{writer.personaConfig.metadata.name}</ContextPanelTitle>
+               <ContextPanelTitle>
+                  {writer.personaConfig.metadata.name}
+               </ContextPanelTitle>
             </ContextPanelHeader>
             <ContextPanelContent>
-               <ContextPanelMeta icon={FileText} label="Conteúdos" value={writer.contentCount ?? 0} />
+               <ContextPanelMeta
+                  icon={FileText}
+                  label="Conteúdos"
+                  value={writer.contentCount ?? 0}
+               />
                <ContextPanelDivider />
                <ContextPanelAction
                   icon={Trash2}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/writers/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/writers/index.tsx
@@ -1,11 +1,11 @@
 import { Button } from "@packages/ui/components/button";
-import { createErrorFallback } from "@packages/ui/components/error-fallback";
 import {
    ContextPanel,
    ContextPanelContent,
    ContextPanelHeader,
    ContextPanelTitle,
 } from "@packages/ui/components/context-panel";
+import { createErrorFallback } from "@packages/ui/components/error-fallback";
 import {
    useMutation,
    useQueryClient,
@@ -20,13 +20,13 @@ import { Loader2, Plus } from "lucide-react";
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { toast } from "sonner";
+import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import {
    type WriterRow,
    WritersTable,
    WritersTableSkeleton,
 } from "@/features/writers/ui/writers-table";
-import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
-import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { orpc } from "@/integrations/orpc/client";
 

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/writers/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/writers/index.tsx
@@ -1,6 +1,12 @@
 import { Button } from "@packages/ui/components/button";
 import { createErrorFallback } from "@packages/ui/components/error-fallback";
 import {
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelHeader,
+   ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
+import {
    useMutation,
    useQueryClient,
    useSuspenseQuery,
@@ -19,6 +25,8 @@ import {
    WritersTable,
    WritersTableSkeleton,
 } from "@/features/writers/ui/writers-table";
+import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { orpc } from "@/integrations/orpc/client";
 
@@ -91,6 +99,32 @@ function WritersContent() {
             toast.error(error.message ?? "Erro ao excluir escritor");
          },
       }),
+   );
+
+   useContextPanelInfo(
+      <ContextPanel>
+         <ContextPanelHeader>
+            <ContextPanelTitle>Ações</ContextPanelTitle>
+         </ContextPanelHeader>
+         <ContextPanelContent>
+            <ContextPanelAction
+               icon={Plus}
+               label="Novo escritor"
+               onClick={() =>
+                  createMutation.mutate({
+                     personaConfig: {
+                        metadata: { name: "Novo escritor" },
+                        instructions: {
+                           ragIntegration: true,
+                           enableInternalLinking: true,
+                           enableFactChecking: false,
+                        },
+                     },
+                  })
+               }
+            />
+         </ContextPanelContent>
+      </ContextPanel>,
    );
 
    function handleEditWriter(writer: WriterRow) {

--- a/apps/web/src/routes/api/chat/$.ts
+++ b/apps/web/src/routes/api/chat/$.ts
@@ -1,7 +1,7 @@
 import { handleChatStream, mastra } from "@packages/agents";
 import { createFileRoute } from "@tanstack/react-router";
-import { createUIMessageStreamResponse } from "ai";
 import type { ModelMessage } from "ai";
+import { createUIMessageStreamResponse } from "ai";
 
 import { auth } from "@/integrations/orpc/server-instances";
 

--- a/docs/plans/2026-02-26-chat-experience-2.md
+++ b/docs/plans/2026-02-26-chat-experience-2.md
@@ -1,0 +1,917 @@
+# Chat Experience 2.0 — PostHog-Style Global AI Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Transform the Contentta chat into a PostHog-style global AI experience with a module-based mode selector, context injection picker, and a platform-router-agent hierarchy.
+
+**Architecture:** The `content-network-agent` is renamed to `content-agent` and extracted as a domain-level orchestrator. A new `platform-router-agent` sits above it as the top-level entry point for all chat surfaces. The Thread composer gains a module-based mode selector (routing prefix injection) and an `@ Add context` picker. Both the context panel tab and the full `/chat` page share the same `Thread` component.
+
+**Tech Stack:** Mastra agents, `@assistant-ui/react`, `@assistant-ui/react-ai-sdk`, oRPC, TanStack Query, Radix UI (Popover, Select), Zod
+
+---
+
+## Context
+
+### Current state
+- `content-network-agent` (`packages/agents/src/mastra/agents/content-network-agent.ts`) orchestrates `research-agent`, `writer-agent`, `seo-auditor-agent`, `reviewer-agent`
+- Registered in Mastra as `"contentNetworkAgent"`, used by `/api/chat` route
+- Chat tab lives at `apps/web/src/features/context-panel/ui/teco-chat-tab.tsx`
+- Thread component at `apps/web/src/features/teco-chat/ui/thread.tsx`
+- Runtime hook at `apps/web/src/features/teco-chat/hooks/use-teco-runtime.ts`
+- Transport POSTs to `/api/chat` with `{ messages, threadId, teamId }`
+
+### Target state
+```
+platform-router-agent  ← new top-level (entry point for /api/chat)
+└── content-agent      ← renamed from content-network-agent
+    ├── research-agent
+    ├── writer-agent
+    ├── seo-auditor-agent
+    └── reviewer-agent
+```
+
+Mode selector in composer → injects routing prefix into last user message server-side → LLM parses and routes
+
+---
+
+## Task 1: Rename content-network-agent → content-agent
+
+**Files:**
+- Rename: `packages/agents/src/mastra/agents/content-network-agent.ts` → `packages/agents/src/mastra/agents/content-agent.ts`
+
+**Step 1: Copy file with new name**
+
+```bash
+cp packages/agents/src/mastra/agents/content-network-agent.ts \
+   packages/agents/src/mastra/agents/content-agent.ts
+```
+
+**Step 2: Update content-agent.ts internals**
+
+Change the agent definition at the bottom of the file:
+
+```typescript
+// Before
+export const contentNetworkAgent: Agent = new Agent({
+  id: "content-network-agent",
+  name: "Content Network Agent",
+  description: "Orchestration agent that routes content tasks to specialized agents...",
+  // ...
+});
+
+// After
+export const contentAgent: Agent = new Agent({
+  id: "content-agent",
+  name: "Content Agent",
+  description: "Content domain orchestrator that routes to research, writing, SEO, and review agents.",
+  // ...
+  // agents config stays the same: research-agent, writer-agent, seo-auditor-agent, reviewer-agent
+});
+```
+
+Update the router instructions function name and content — add one line at the top of the instructions:
+
+```typescript
+// In getRouterInstructions(), add at the start of the returned string:
+`# CONTENT AGENT — DOMAIN ROUTER
+
+You are the content domain orchestrator. You receive tasks from the platform router.
+When you receive a prefix like "[Usar writer-agent]:", route directly to that agent without your own reasoning.
+
+// ... rest of existing instructions unchanged
+```
+
+**Step 3: Delete old file**
+
+```bash
+rm packages/agents/src/mastra/agents/content-network-agent.ts
+```
+
+**Step 4: Commit**
+
+```bash
+git add packages/agents/src/mastra/agents/content-agent.ts
+git rm packages/agents/src/mastra/agents/content-network-agent.ts
+git commit -m "refactor(agents): rename content-network-agent to content-agent"
+```
+
+---
+
+## Task 2: Create platform-router-agent
+
+**Files:**
+- Create: `packages/agents/src/mastra/agents/platform-router-agent.ts`
+
+**Step 1: Create the file**
+
+```typescript
+// packages/agents/src/mastra/agents/platform-router-agent.ts
+import { Agent } from "@mastra/core/agent";
+import { Memory } from "@mastra/memory";
+import type { InstructionMemoryItem } from "@packages/database/schemas/instruction-memory";
+import { DEFAULT_CONTENT_MODEL_ID } from "../../models";
+import {
+  buildLanguageInstruction,
+  compileInstructionMemories,
+} from "../../utils";
+import { contentAgent } from "./content-agent";
+
+const memory = new Memory({
+  options: {
+    lastMessages: 30,
+    generateTitle: {
+      model: "openrouter/google/gemini-2.5-flash-lite",
+    },
+  },
+});
+
+const getPlatformRouterInstructions = (
+  language: string,
+  writerInstructions?: InstructionMemoryItem[],
+): string => {
+  const compiledMemories = compileInstructionMemories(writerInstructions ?? []);
+  const languageInstruction = buildLanguageInstruction(language);
+
+  return `
+${languageInstruction}
+
+${compiledMemories}
+
+# PLATFORM ROUTER
+
+You are the top-level orchestrator for the Contentta platform.
+Your job: understand what the user wants and route to the right domain agent, or answer directly.
+
+## YOUR AGENTS
+
+**content-agent** — Content Domain Agent
+Use when: anything related to content creation, writing, research, SEO, review, editing, planning articles
+
+## ROUTING RULES
+
+1. **Content-related request** → content-agent (pass the full message including any routing prefixes)
+2. **Platform question** (how to use the platform, navigation, features) → answer directly
+3. **Prefixed request** (e.g., "[Usar writer-agent]: ...") → content-agent (it will handle the prefix)
+
+## IMPORTANT
+
+- You DO NOT have tools yourself — content-agent and its specialists do
+- For simple questions (definitions, how-to platform help), answer directly without routing
+- Always include the agent's full output in your final response
+- Pass routing prefixes (e.g., "[Usar writer-agent]:") unchanged to content-agent
+
+Respond in the same language as the user request.
+`;
+};
+
+export const platformRouterAgent: Agent = new Agent({
+  id: "platform-router-agent",
+  name: "Platform Router Agent",
+  description:
+    "Top-level platform orchestrator. Routes content tasks to content-agent and answers platform questions directly.",
+
+  model: ({ requestContext }) => {
+    const maybeModel = requestContext?.get("model");
+    return typeof maybeModel === "string" && maybeModel.length > 0
+      ? maybeModel
+      : DEFAULT_CONTENT_MODEL_ID;
+  },
+
+  instructions: ({ requestContext }) => {
+    const writerInstructions = requestContext?.get("writerInstructions") as
+      | InstructionMemoryItem[]
+      | undefined;
+    const language = (requestContext?.get("language") as string) ?? "pt-BR";
+    return getPlatformRouterInstructions(language, writerInstructions);
+  },
+
+  memory,
+
+  agents: {
+    "content-agent": contentAgent,
+  },
+
+  tools: {},
+});
+```
+
+**Step 2: Verify the file was created**
+
+```bash
+cat packages/agents/src/mastra/agents/platform-router-agent.ts | head -20
+```
+
+Expected: Shows the import and agent creation.
+
+**Step 3: Commit**
+
+```bash
+git add packages/agents/src/mastra/agents/platform-router-agent.ts
+git commit -m "feat(agents): add platform-router-agent as top-level orchestrator"
+```
+
+---
+
+## Task 3: Update Mastra registration
+
+**Files:**
+- Modify: `packages/agents/src/mastra/index.ts`
+
+**Step 1: Update imports and registration**
+
+Replace the `contentNetworkAgent` import with the new exports:
+
+```typescript
+// Remove:
+import { contentNetworkAgent } from "./agents/content-network-agent";
+
+// Add:
+import { platformRouterAgent } from "./agents/platform-router-agent";
+import { contentAgent } from "./agents/content-agent";
+```
+
+In the Mastra instance agents config, replace `contentNetworkAgent` with both new agents:
+
+```typescript
+// Before
+agents: {
+  contentNetworkAgent,
+  researchAgent,
+  writerAgent,
+  seoAuditorAgent,
+  reviewerAgent,
+  fimAgent,
+  inlineEditAgent,
+}
+
+// After
+agents: {
+  platformRouterAgent,
+  contentAgent,
+  researchAgent,
+  writerAgent,
+  seoAuditorAgent,
+  reviewerAgent,
+  fimAgent,
+  inlineEditAgent,
+}
+```
+
+**Step 2: Update createRequestContext exports if referenced**
+
+Check if `createRequestContext` or any re-exports reference `contentNetworkAgent` by name:
+
+```bash
+grep -r "contentNetworkAgent" packages/agents/src/
+```
+
+Fix any remaining references.
+
+**Step 3: Verify TypeScript compiles**
+
+```bash
+bun run typecheck
+```
+
+Expected: No errors in `packages/agents/`.
+
+**Step 4: Commit**
+
+```bash
+git add packages/agents/src/mastra/index.ts
+git commit -m "refactor(agents): register platformRouterAgent, replace contentNetworkAgent"
+```
+
+---
+
+## Task 4: Update /api/chat route to use platformRouterAgent + accept mode param
+
+**Files:**
+- Modify: `apps/web/src/routes/api/chat/$.ts`
+
+**Step 1: Update agent ID**
+
+Find the `handleChatStream` call and change the agent ID:
+
+```typescript
+// Before
+await handleChatStream({
+  agentId: "contentNetworkAgent",
+  // ...
+});
+
+// After
+await handleChatStream({
+  agentId: "platformRouterAgent",
+  // ...
+});
+```
+
+**Step 2: Accept and apply the `mode` parameter**
+
+Add mode-to-prefix mapping and inject prefix into last user message:
+
+```typescript
+const MODE_ROUTING_PREFIX: Record<string, string> = {
+  auto: "",
+  content: "[Usar writer-agent]:",
+  research: "[Usar research-agent]:",
+  seo: "[Usar seo-auditor-agent]:",
+  review: "[Usar reviewer-agent]:",
+};
+
+// In the request handler, after extracting messages:
+const body = await request.json();
+const { messages, threadId, teamId, mode = "auto" } = body;
+
+// Inject prefix into the last user message
+const prefix = MODE_ROUTING_PREFIX[mode] ?? "";
+const processedMessages = prefix
+  ? messages.map((msg: CoreMessage, idx: number) => {
+      if (idx === messages.length - 1 && msg.role === "user") {
+        const content =
+          typeof msg.content === "string"
+            ? `${prefix} ${msg.content}`
+            : msg.content;
+        return { ...msg, content };
+      }
+      return msg;
+    })
+  : messages;
+```
+
+**Step 3: Verify TypeScript compiles**
+
+```bash
+bun run typecheck
+```
+
+Expected: No type errors in `apps/web/src/routes/api/chat/$.ts`.
+
+**Step 4: Commit**
+
+```bash
+git add apps/web/src/routes/api/chat/$.ts
+git commit -m "feat(chat): route to platformRouterAgent, inject mode prefix into messages"
+```
+
+---
+
+## Task 5: Update useTecoRuntime to pass mode
+
+**Files:**
+- Modify: `apps/web/src/features/teco-chat/hooks/use-teco-runtime.ts`
+
+**Step 1: Accept mode as parameter**
+
+Update the hook signature to accept an optional `mode` parameter:
+
+```typescript
+interface UseTecoRuntimeOptions {
+  teamId: string;
+  mode?: string; // "auto" | "content" | "research" | "seo" | "review"
+}
+
+export function useTecoRuntime({ teamId, mode = "auto" }: UseTecoRuntimeOptions) {
+```
+
+**Step 2: Pass mode in transport body**
+
+Find where `AssistantChatTransport` is created and add `mode` to the body:
+
+```typescript
+new AssistantChatTransport({
+  api: "/api/chat",
+  body: { teamId, threadId: threadIdRef.current, mode },
+})
+```
+
+Since `mode` can change, it needs to be read reactively. Check how `threadId` is currently handled (via ref) and apply the same pattern for `mode`:
+
+```typescript
+const modeRef = useRef(mode);
+useEffect(() => { modeRef.current = mode; }, [mode]);
+
+// In transport body:
+body: { teamId, threadId: threadIdRef.current, mode: modeRef.current },
+```
+
+**Step 3: Verify TypeScript compiles**
+
+```bash
+bun run typecheck
+```
+
+**Step 4: Commit**
+
+```bash
+git add apps/web/src/features/teco-chat/hooks/use-teco-runtime.ts
+git commit -m "feat(chat): pass mode to /api/chat transport for agent routing"
+```
+
+---
+
+## Task 6: Add mode selector to Thread composer
+
+**Files:**
+- Modify: `apps/web/src/features/teco-chat/ui/thread.tsx`
+
+**Step 1: Add mode state and constants**
+
+At the top of `thread.tsx`, add:
+
+```typescript
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@packages/ui/components/select";
+
+const MODES = [
+  { value: "auto", label: "Auto", icon: "⚡" },
+  { value: "content", label: "Conteúdo", icon: "✍️" },
+  { value: "research", label: "Pesquisa", icon: "🔍" },
+  { value: "seo", label: "SEO", icon: "📊" },
+  { value: "review", label: "Revisão", icon: "✅" },
+] as const;
+
+type Mode = (typeof MODES)[number]["value"];
+```
+
+**Step 2: Thread component accepts onModeChange**
+
+Update the `Thread` component props:
+
+```typescript
+interface ThreadProps {
+  suggestions?: { label: string; prompt: string }[];
+  onModeChange?: (mode: Mode) => void;
+  defaultMode?: Mode;
+}
+
+export function Thread({ suggestions = [], onModeChange, defaultMode = "auto" }: ThreadProps) {
+  const [mode, setMode] = useState<Mode>(defaultMode);
+
+  const handleModeChange = (value: Mode) => {
+    setMode(value);
+    onModeChange?.(value);
+  };
+  // ...
+}
+```
+
+**Step 3: Add mode selector to Composer**
+
+Inside the `Composer` section (below the `ComposerPrimitive.Input`), add the mode selector in the composer footer row:
+
+```tsx
+<div className="flex items-center gap-2 px-3 pb-2">
+  <Select value={mode} onValueChange={handleModeChange}>
+    <SelectTrigger className="h-7 w-auto gap-1 border-none bg-transparent px-2 text-xs text-muted-foreground shadow-none hover:bg-accent">
+      <SelectValue />
+    </SelectTrigger>
+    <SelectContent align="start">
+      {MODES.map((m) => (
+        <SelectItem key={m.value} value={m.value} className="text-xs">
+          {m.label}
+        </SelectItem>
+      ))}
+    </SelectContent>
+  </Select>
+</div>
+```
+
+**Step 4: Visually verify**
+
+Run the dev server and open the context panel chat tab. Confirm the mode selector appears below the composer input.
+
+```bash
+bun dev
+```
+
+**Step 5: Commit**
+
+```bash
+git add apps/web/src/features/teco-chat/ui/thread.tsx
+git commit -m "feat(chat): add module mode selector to Thread composer"
+```
+
+---
+
+## Task 7: Connect mode selector to useTecoRuntime
+
+**Files:**
+- Modify: `apps/web/src/features/context-panel/ui/teco-chat-tab.tsx`
+- Modify: `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat.tsx`
+
+**Step 1: Add mode state in TecoChatTab**
+
+```typescript
+// In teco-chat-tab.tsx
+const [mode, setMode] = useState<string>("auto");
+const runtime = useTecoRuntime({ teamId, mode });
+
+// Pass to Thread:
+<Thread suggestions={QUICK_SUGGESTIONS} onModeChange={setMode} />
+```
+
+**Step 2: Same pattern in full chat page**
+
+```typescript
+// In chat.tsx (layout level)
+const [mode, setMode] = useState<string>("auto");
+const runtime = useTecoRuntime({ teamId, mode });
+
+// Pass down to Thread via Outlet context or prop
+```
+
+**Step 3: Verify mode changes update the transport**
+
+Send a message in "Pesquisa" mode, check the network tab in browser DevTools — the POST body to `/api/chat` should include `"mode": "research"`.
+
+**Step 4: Commit**
+
+```bash
+git add apps/web/src/features/context-panel/ui/teco-chat-tab.tsx
+git add apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat.tsx
+git commit -m "feat(chat): wire mode state to useTecoRuntime in both chat surfaces"
+```
+
+---
+
+## Task 8: Add @ Add context picker to Thread composer
+
+**Files:**
+- Create: `apps/web/src/features/teco-chat/ui/context-picker.tsx`
+- Modify: `apps/web/src/features/teco-chat/ui/thread.tsx`
+
+**Step 1: Create ContextPicker component**
+
+```typescript
+// apps/web/src/features/teco-chat/ui/context-picker.tsx
+import { useState } from "react";
+import { AtSign, FileText, Search } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@packages/ui/components/popover";
+import { Button } from "@packages/ui/components/button";
+import { Input } from "@packages/ui/components/input";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { orpc } from "@/integrations/orpc/client";
+
+interface ContextItem {
+  type: "content" | "current-document";
+  id: string;
+  label: string;
+  preview: string; // short excerpt or description
+}
+
+interface ContextPickerProps {
+  teamId: string;
+  onSelect: (item: ContextItem) => void;
+  currentDocumentId?: string; // present when in editor
+}
+
+export function ContextPicker({ teamId, onSelect, currentDocumentId }: ContextPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const { data: contents } = useSuspenseQuery(
+    orpc.content.getAll.queryOptions({ input: { teamId } }),
+  );
+
+  const filtered = contents?.filter((c) =>
+    c.title?.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const handleSelect = (item: ContextItem) => {
+    onSelect(item);
+    setOpen(false);
+    setSearch("");
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1 px-2 text-xs text-muted-foreground"
+        >
+          <AtSign className="size-3" />
+          Adicionar contexto
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-80 p-0" side="top">
+        <div className="border-b p-2">
+          <div className="relative">
+            <Search className="absolute left-2 top-2 size-3.5 text-muted-foreground" />
+            <Input
+              className="h-8 pl-7 text-xs"
+              placeholder="Pesquisar conteúdos..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              autoFocus
+            />
+          </div>
+        </div>
+
+        <div className="max-h-64 overflow-y-auto">
+          {currentDocumentId && (
+            <div className="border-b">
+              <p className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                Documento atual
+              </p>
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs hover:bg-accent"
+                onClick={() =>
+                  handleSelect({
+                    type: "current-document",
+                    id: currentDocumentId,
+                    label: "Documento atual",
+                    preview: "",
+                  })
+                }
+              >
+                <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+                <span>Usar documento aberto</span>
+              </button>
+            </div>
+          )}
+
+          <p className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            Conteúdos
+          </p>
+          {filtered?.map((content) => (
+            <button
+              type="button"
+              key={content.id}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs hover:bg-accent"
+              onClick={() =>
+                handleSelect({
+                  type: "content",
+                  id: content.id,
+                  label: content.title ?? "Sem título",
+                  preview: content.description ?? "",
+                })
+              }
+            >
+              <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+              <span className="truncate">{content.title ?? "Sem título"}</span>
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+```
+
+**Step 2: Add context items state to Thread**
+
+In `thread.tsx`, add state for selected context items and append them to the message on send:
+
+```typescript
+interface ContextItem {
+  type: "content" | "current-document";
+  id: string;
+  label: string;
+  preview: string;
+}
+
+// In Thread component:
+const [contextItems, setContextItems] = useState<ContextItem[]>([]);
+
+const handleContextSelect = (item: ContextItem) => {
+  setContextItems((prev) => [...prev, item]);
+};
+
+// Show selected context chips above the composer input:
+{contextItems.length > 0 && (
+  <div className="flex flex-wrap gap-1 px-3 pt-2">
+    {contextItems.map((item) => (
+      <span
+        key={item.id}
+        className="flex items-center gap-1 rounded-full bg-accent px-2 py-0.5 text-xs"
+      >
+        @{item.label}
+        <button
+          type="button"
+          onClick={() => setContextItems((prev) => prev.filter((i) => i.id !== item.id))}
+          className="text-muted-foreground hover:text-foreground"
+        >
+          ×
+        </button>
+      </span>
+    ))}
+  </div>
+)}
+```
+
+**Step 3: Append context to message before send**
+
+Wrap the composer submit to append context block. Since `@assistant-ui/react` uses `ComposerPrimitive.Send`, intercept via `onBeforeSubmit` or by using `useComposer`:
+
+```typescript
+// Context is passed via additional body in the transport
+// Simpler: serialize context items and append to message text
+
+// In the Composer, override the send button to prepend context:
+const handleSendWithContext = () => {
+  if (contextItems.length === 0) return; // let default send handle it
+  const contextBlock = contextItems
+    .map((item) => `[Contexto: ${item.label}]`)
+    .join("\n");
+  // Programmatically append to current composer value before submit
+  // Implementation depends on @assistant-ui/react API — check useComposer hook
+  setContextItems([]);
+};
+```
+
+> **Note:** Check the `@assistant-ui/react` docs for `useComposer` to get/set the composer value programmatically. The exact API may be `useComposer().setValue(...)` or similar.
+
+**Step 4: Add ContextPicker to composer footer**
+
+```tsx
+// In the composer footer row next to the mode selector:
+<ContextPicker
+  teamId={teamId}
+  onSelect={handleContextSelect}
+  currentDocumentId={currentDocumentId}
+/>
+```
+
+**Step 5: Commit**
+
+```bash
+git add apps/web/src/features/teco-chat/ui/context-picker.tsx
+git add apps/web/src/features/teco-chat/ui/thread.tsx
+git commit -m "feat(chat): add @ context picker to Thread composer"
+```
+
+---
+
+## Task 9: PostHog-style empty state for full /chat page
+
+**Files:**
+- Modify: `apps/web/src/features/teco-chat/ui/thread.tsx` (welcome/empty state section)
+
+The current empty state shows a simple welcome. Update it to PostHog-style: centered, prominent composer, suggestion chips in a grid below.
+
+**Step 1: Update empty thread state**
+
+Find the empty/welcome state section in `thread.tsx` and update:
+
+```tsx
+// Empty thread welcome state
+<div className="flex flex-1 flex-col items-center justify-center gap-6 p-8">
+  <div className="flex flex-col items-center gap-2 text-center">
+    <div className="text-4xl font-semibold tracking-tight">
+      O que você quer criar?
+    </div>
+    <p className="text-sm text-muted-foreground">
+      Pesquise, escreva, audite SEO ou revise conteúdos.
+    </p>
+  </div>
+
+  {/* Suggestion chips */}
+  {suggestions.length > 0 && (
+    <div className="flex flex-wrap justify-center gap-2">
+      {suggestions.map((s) => (
+        <button
+          type="button"
+          key={s.label}
+          className="rounded-full border border-border bg-background px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground"
+          onClick={() => {/* pre-fill composer */}}
+        >
+          {s.label}
+        </button>
+      ))}
+    </div>
+  )}
+</div>
+```
+
+**Step 2: Wire suggestion chip click to pre-fill composer**
+
+Use `@assistant-ui/react`'s `useComposer` hook to set the value:
+
+```typescript
+import { useComposer } from "@assistant-ui/react";
+
+// Inside Composer context:
+const composer = useComposer();
+// On chip click:
+composer.setValue(s.prompt);
+composer.focus();
+```
+
+**Step 3: Commit**
+
+```bash
+git add apps/web/src/features/teco-chat/ui/thread.tsx
+git commit -m "feat(chat): PostHog-style empty state with centered composer and suggestion chips"
+```
+
+---
+
+## Task 10: Update AgentNetworkStatus display names
+
+**Files:**
+- Modify: `apps/web/src/features/teco-chat/ui/thread.tsx` (or wherever `AGENT_DISPLAY_NAMES` lives)
+
+**Step 1: Update agent display names**
+
+```typescript
+const AGENT_DISPLAY_NAMES: Record<string, string> = {
+  "platform-router-agent": "Plataforma",
+  "content-agent": "Conteúdo",
+  "research-agent": "Pesquisa",
+  "writer-agent": "Redação",
+  "seo-auditor-agent": "SEO",
+  "reviewer-agent": "Revisão",
+  "fim-agent": "Autocomplete",
+  "inline-edit-agent": "Edição",
+};
+```
+
+**Step 2: Commit**
+
+```bash
+git add apps/web/src/features/teco-chat/ui/thread.tsx
+git commit -m "chore(chat): update agent display names for new network hierarchy"
+```
+
+---
+
+## Task 11: Update CLAUDE.md agent references
+
+**Files:**
+- Modify: `/home/yorizel/Documents/contentta-nx/CLAUDE.md`
+
+**Step 1: Update the AI Agents section**
+
+Replace references to `unifiedContent` / `contentNetworkAgent` with the new names:
+
+```markdown
+**Usage in routers:**
+```typescript
+const agent = mastra.getAgent("platformRouterAgent");
+```
+
+Update the agent hierarchy description to reflect:
+- `platform-router-agent` (top-level)
+- `content-agent` (content domain orchestrator)
+- Sub-agents: research, writer, seo-auditor, reviewer
+```
+
+**Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md with new agent network hierarchy"
+```
+
+---
+
+## Checklist
+
+- [ ] Task 1: content-network-agent → content-agent (file rename + internals)
+- [ ] Task 2: platform-router-agent created
+- [ ] Task 3: Mastra registration updated
+- [ ] Task 4: /api/chat uses platformRouterAgent + mode prefix injection
+- [ ] Task 5: useTecoRuntime accepts and passes mode
+- [ ] Task 6: Thread composer has mode selector
+- [ ] Task 7: Mode selector wired to useTecoRuntime in both surfaces
+- [ ] Task 8: @ Add context picker
+- [ ] Task 9: PostHog-style empty state
+- [ ] Task 10: Agent display names updated
+- [ ] Task 11: CLAUDE.md updated
+
+---
+
+## Testing
+
+After all tasks, test these scenarios manually:
+
+1. **Auto mode** — send "escreva um artigo sobre TypeScript" — should route through content-agent → writer-agent
+2. **Research mode** — select "Pesquisa", send "pesquise sobre SEO em 2026" — body should show `mode: "research"`, prefix `[Usar research-agent]:` injected
+3. **Context panel vs full chat** — both surfaces show mode selector, both pass mode to /api/chat
+4. **@ context picker** — open picker, select a content, see `@Title` chip in composer
+5. **Empty state** — new thread shows welcome state with suggestion chips; clicking chip pre-fills composer
+6. **AgentNetworkStatus** — correct display names shown while agents run
+
+---
+
+## Related Issues
+
+- #606 — Chat Experience 2.0 (this plan)
+- #613 — Agent Networks migration
+- #616 — Platform Agent + Onboarding Agent
+- #695 — Context Panel Global (completed)
+- #696 — Context Panel tabs (completed)

--- a/docs/plans/2026-02-26-context-panel-primitives.md
+++ b/docs/plans/2026-02-26-context-panel-primitives.md
@@ -1,0 +1,650 @@
+# ContextPanel Composition Primitives Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add PostHog-style composition primitives (`ContextPanel`, `ContextPanelHeader`, `ContextPanelTitle`, `ContextPanelHeaderActions`, `ContextPanelContent`, `ContextPanelFooter`) to `@packages/ui` and migrate all existing ContextPanel callers to the new pattern.
+
+**Architecture:** New primitives live in `packages/ui/src/components/context-panel.tsx` as plain styled divs (same pattern as `sidebar.tsx` — `data-slot` + `cn()`). The `ContextPanelSection` helper (title-based) is removed from `context-panel-info.tsx` and replaced by the composable header. All 4 caller sites are migrated mechanically.
+
+**Tech Stack:** React, Tailwind CSS, `cn()` from `@packages/ui/lib/utils`, TanStack Router (`useNavigate`, `useParams`), Lucide React (`ArrowUpRight`)
+
+---
+
+## Key facts before starting
+
+- `packages/ui/package.json` has wildcard `"./components/*"` export — **no package.json change needed**; the new file is auto-exported.
+- `apps/web/src/features/context-panel/context-panel.tsx` already has `overflow-hidden` on `SidebarContent`, but wraps content in an extra `<div className="h-full rounded-b-xl bg-muted">`. The fix is to remove that wrapper and move its classes to `SidebarContent` directly.
+- There are **two different things** named `ContextPanelHeaderActions`:
+  - OLD: `apps/web/src/features/context-panel/context-panel-header-actions.tsx` — top-bar buttons (AI + panel toggle). Do NOT touch.
+  - NEW: primitive in `packages/ui/src/components/context-panel.tsx` — used inside tab content.
+- The `ChatContent` function in `context-panel.tsx` needs `useNavigate` + `useParams` from TanStack Router (same pattern already used in `teco-chat-tab.tsx`).
+- After migrating callers, `ContextPanelSection` import is removed from each file, and `ContextPanelSection` is removed from `context-panel-info.tsx`.
+
+---
+
+## Task 1: Create the primitive component file
+
+**Files:**
+- Create: `packages/ui/src/components/context-panel.tsx`
+
+**Step 1: Create the file with all 6 primitives**
+
+```tsx
+import { cn } from "@packages/ui/lib/utils";
+import type React from "react";
+
+function ContextPanel({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn("flex h-full min-h-0 flex-col", className)}
+			data-slot="context-panel"
+			{...props}
+		/>
+	);
+}
+
+function ContextPanelHeader({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn(
+				"flex shrink-0 items-center gap-2 border-b px-3 py-2",
+				className,
+			)}
+			data-slot="context-panel-header"
+			{...props}
+		/>
+	);
+}
+
+function ContextPanelTitle({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn("flex-1 text-sm font-semibold", className)}
+			data-slot="context-panel-title"
+			{...props}
+		/>
+	);
+}
+
+function ContextPanelHeaderActions({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn("flex items-center gap-1", className)}
+			data-slot="context-panel-header-actions"
+			{...props}
+		/>
+	);
+}
+
+function ContextPanelContent({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn("flex min-h-0 flex-1 flex-col overflow-auto", className)}
+			data-slot="context-panel-content"
+			{...props}
+		/>
+	);
+}
+
+function ContextPanelFooter({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn("flex shrink-0 flex-col border-t p-2", className)}
+			data-slot="context-panel-footer"
+			{...props}
+		/>
+	);
+}
+
+export {
+	ContextPanel,
+	ContextPanelContent,
+	ContextPanelFooter,
+	ContextPanelHeader,
+	ContextPanelHeaderActions,
+	ContextPanelTitle,
+};
+```
+
+**Step 2: Verify TypeScript compiles**
+
+```bash
+bun run typecheck 2>&1 | head -30
+```
+
+Expected: no errors in `packages/ui/src/components/context-panel.tsx`
+
+**Step 3: Commit**
+
+```bash
+git add packages/ui/src/components/context-panel.tsx
+git commit -m "feat(ui): add ContextPanel composition primitives"
+```
+
+---
+
+## Task 2: Update `context-panel.tsx` — InfoContent, ChatContent, SidebarContent
+
+**Files:**
+- Modify: `apps/web/src/features/context-panel/context-panel.tsx`
+
+**Step 1: Read the full current file** (already read — line-by-line reference below)
+
+Current state:
+- Line 1: `"use client";`
+- Lines 3–16: imports
+- Lines 28–34: `CHAT_TAB` with `<TecoChatTab />` as content
+- Lines 36–39: `InfoContent()` returns `<>{infoContent}<>`
+- Lines 41–47: `INFO_TAB`
+- Lines 107–111: `<SidebarContent className=" overflow-hidden h-full"><div className="h-full rounded-b-xl bg-muted ">{activeTab?.content}</div></SidebarContent>`
+
+**Step 2: Apply all 3 changes to `context-panel.tsx`**
+
+**Change A — New imports (add at top):**
+
+Add these imports after the existing import block:
+```tsx
+import {
+	ContextPanel,
+	ContextPanelContent,
+	ContextPanelHeader,
+	ContextPanelHeaderActions,
+	ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
+import { ArrowUpRight } from "lucide-react";
+import { useNavigate, useParams } from "@tanstack/react-router";
+```
+
+**Change B — Replace `InfoContent` and add `ChatContent`, update tabs:**
+
+Replace the `InfoContent` function + `INFO_TAB` + `CHAT_TAB` block with:
+
+```tsx
+function InfoContent() {
+	const { infoContent } = useStore(contextPanelStore);
+	if (!infoContent) {
+		return (
+			<ContextPanel>
+				<ContextPanelContent className="flex items-center justify-center p-6">
+					<p className="text-sm text-muted-foreground/50">Sem informações</p>
+				</ContextPanelContent>
+			</ContextPanel>
+		);
+	}
+	return <>{infoContent}</>;
+}
+
+function ChatContent() {
+	const navigate = useNavigate();
+	const { slug, teamSlug } = useParams({
+		from: "/_authenticated/$slug/$teamSlug/_dashboard",
+	});
+
+	return (
+		<ContextPanel>
+			<ContextPanelHeader>
+				<ContextPanelTitle>Chat IA</ContextPanelTitle>
+				<ContextPanelHeaderActions>
+					<Button
+						className="size-6 rounded"
+						onClick={() =>
+							navigate({
+								to: "/$slug/$teamSlug/chat",
+								params: { slug, teamSlug },
+							})
+						}
+						size="icon"
+						type="button"
+						variant="ghost"
+					>
+						<ArrowUpRight className="size-3.5" />
+					</Button>
+				</ContextPanelHeaderActions>
+			</ContextPanelHeader>
+			<ContextPanelContent>
+				<TecoChatTab />
+			</ContextPanelContent>
+		</ContextPanel>
+	);
+}
+
+const CHAT_TAB: ContextPanelTab = {
+	id: "chat",
+	icon: MessageSquare,
+	label: "Chat IA",
+	content: <ChatContent />,
+	order: 1,
+};
+
+const INFO_TAB: ContextPanelTab = {
+	id: "info",
+	icon: Info,
+	label: "Informações",
+	content: <InfoContent />,
+	order: 0,
+};
+```
+
+**Change C — Fix SidebarContent (remove inner div wrapper):**
+
+Replace:
+```tsx
+<SidebarContent className=" overflow-hidden h-full">
+   <div className="h-full rounded-b-xl bg-muted ">
+      {activeTab?.content}
+   </div>
+</SidebarContent>
+```
+
+With:
+```tsx
+<SidebarContent className="h-full overflow-hidden rounded-b-xl bg-muted">
+   {activeTab?.content}
+</SidebarContent>
+```
+
+**Step 3: Verify TypeScript**
+
+```bash
+bun run typecheck 2>&1 | head -40
+```
+
+Expected: no new errors
+
+**Step 4: Commit**
+
+```bash
+git add apps/web/src/features/context-panel/context-panel.tsx
+git commit -m "feat(context-panel): add InfoContent empty state, ChatContent with expand, fix SidebarContent overflow"
+```
+
+---
+
+## Task 3: Remove `ContextPanelSection` from `context-panel-info.tsx`
+
+**Files:**
+- Modify: `apps/web/src/features/context-panel/context-panel-info.tsx`
+
+**Step 1: Remove the `ContextPanelSection` function**
+
+The file currently contains `ContextPanelSection` (lines 5–24) plus `ContextPanelAction`, `ContextPanelMeta`, `ContextPanelDivider`.
+
+Delete only the `ContextPanelSection` export (lines 5–24). Keep everything else unchanged.
+
+After: file starts at `export function ContextPanelAction(...)`.
+
+**Step 2: Commit**
+
+```bash
+git add apps/web/src/features/context-panel/context-panel-info.tsx
+git commit -m "feat(context-panel): remove ContextPanelSection (replaced by ContextPanelHeader primitives)"
+```
+
+---
+
+## Task 4: Migrate `content-list-section.tsx`
+
+**Files:**
+- Modify: `apps/web/src/features/content/ui/content-list-section.tsx`
+
+**Step 1: Update import**
+
+Replace:
+```tsx
+import {
+   ContextPanelAction,
+   ContextPanelSection,
+} from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
+```
+
+With:
+```tsx
+import {
+	ContextPanel,
+	ContextPanelContent,
+	ContextPanelHeader,
+	ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
+import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
+```
+
+**Step 2: Update `useContextPanelInfo` call**
+
+Replace:
+```tsx
+useContextPanelInfo(
+   <ContextPanelSection title="Ações">
+      <ContextPanelAction
+         icon={Plus}
+         label="Novo conteúdo"
+         onClick={handleCreateNew}
+      />
+   </ContextPanelSection>,
+);
+```
+
+With:
+```tsx
+useContextPanelInfo(
+	<ContextPanel>
+		<ContextPanelHeader>
+			<ContextPanelTitle>Ações</ContextPanelTitle>
+		</ContextPanelHeader>
+		<ContextPanelContent>
+			<ContextPanelAction
+				icon={Plus}
+				label="Novo conteúdo"
+				onClick={handleCreateNew}
+			/>
+		</ContextPanelContent>
+	</ContextPanel>,
+);
+```
+
+**Step 3: Verify TypeScript**
+
+```bash
+bun run typecheck 2>&1 | head -30
+```
+
+**Step 4: Commit**
+
+```bash
+git add apps/web/src/features/content/ui/content-list-section.tsx
+git commit -m "feat(content): migrate ContextPanelSection to new primitives"
+```
+
+---
+
+## Task 5: Migrate `dashboards/index.tsx`
+
+**Files:**
+- Modify: `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/index.tsx`
+
+**Step 1: Update import**
+
+Replace:
+```tsx
+import {
+   ContextPanelAction,
+   ContextPanelSection,
+} from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
+```
+
+With:
+```tsx
+import {
+	ContextPanel,
+	ContextPanelContent,
+	ContextPanelHeader,
+	ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
+import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
+```
+
+**Step 2: Update `useContextPanelInfo` call**
+
+Replace:
+```tsx
+useContextPanelInfo(
+   <ContextPanelSection title="Ações">
+      <ContextPanelAction
+         icon={Plus}
+         label="Novo dashboard"
+         onClick={() => {
+            // TODO: Wire to create dashboard action
+         }}
+      />
+   </ContextPanelSection>,
+);
+```
+
+With:
+```tsx
+useContextPanelInfo(
+	<ContextPanel>
+		<ContextPanelHeader>
+			<ContextPanelTitle>Ações</ContextPanelTitle>
+		</ContextPanelHeader>
+		<ContextPanelContent>
+			<ContextPanelAction
+				icon={Plus}
+				label="Novo dashboard"
+				onClick={() => {
+					// TODO: Wire to create dashboard action
+				}}
+			/>
+		</ContextPanelContent>
+	</ContextPanel>,
+);
+```
+
+**Step 3: Commit**
+
+```bash
+git add apps/web/src/routes/_authenticated/\$slug/\$teamSlug/_dashboard/analytics/dashboards/index.tsx
+git commit -m "feat(dashboards): migrate ContextPanelSection to new primitives"
+```
+
+---
+
+## Task 6: Migrate `forms/index.tsx`
+
+**Files:**
+- Modify: `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/forms/index.tsx`
+
+**Step 1: Update import**
+
+Replace:
+```tsx
+import {
+   ContextPanelAction,
+   ContextPanelSection,
+} from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
+```
+
+With:
+```tsx
+import {
+	ContextPanel,
+	ContextPanelContent,
+	ContextPanelHeader,
+	ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
+import { ContextPanelAction } from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
+```
+
+**Step 2: Update `useContextPanelInfo` call**
+
+Replace:
+```tsx
+useContextPanelInfo(
+   <ContextPanelSection title="Ações">
+      <ContextPanelAction
+         icon={Plus}
+         label="Novo formulário"
+         onClick={() =>
+            navigate({
+               to: "/$slug/$teamSlug/forms/$formId",
+               params: { slug, teamSlug, formId: "new" },
+            })
+         }
+      />
+   </ContextPanelSection>,
+);
+```
+
+With:
+```tsx
+useContextPanelInfo(
+	<ContextPanel>
+		<ContextPanelHeader>
+			<ContextPanelTitle>Ações</ContextPanelTitle>
+		</ContextPanelHeader>
+		<ContextPanelContent>
+			<ContextPanelAction
+				icon={Plus}
+				label="Novo formulário"
+				onClick={() =>
+					navigate({
+						to: "/$slug/$teamSlug/forms/$formId",
+						params: { slug, teamSlug, formId: "new" },
+					})
+				}
+			/>
+		</ContextPanelContent>
+	</ContextPanel>,
+);
+```
+
+**Step 3: Commit**
+
+```bash
+git add apps/web/src/routes/_authenticated/\$slug/\$teamSlug/_dashboard/forms/index.tsx
+git commit -m "feat(forms): migrate ContextPanelSection to new primitives"
+```
+
+---
+
+## Task 7: Migrate `editor-context-panel-tabs.tsx`
+
+**Files:**
+- Modify: `apps/web/src/features/editor/plate/ui/editor-context-panel-tabs.tsx`
+
+**Step 1: Update imports**
+
+Add new imports at top:
+```tsx
+import {
+	ContextPanel,
+	ContextPanelContent,
+	ContextPanelHeader,
+	ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
+```
+
+**Step 2: Wrap `settings` tab content**
+
+Replace:
+```tsx
+registerTab({
+   id: "settings",
+   icon: Settings2,
+   label: "Metadados",
+   content: (
+      <FrontmatterSection
+         meta={meta}
+         onChange={onChange}
+         readOnly={readOnly}
+      />
+   ),
+   order: 1,
+});
+```
+
+With:
+```tsx
+registerTab({
+	id: "settings",
+	icon: Settings2,
+	label: "Metadados",
+	content: (
+		<ContextPanel>
+			<ContextPanelHeader>
+				<ContextPanelTitle>Metadados</ContextPanelTitle>
+			</ContextPanelHeader>
+			<ContextPanelContent>
+				<FrontmatterSection
+					meta={meta}
+					onChange={onChange}
+					readOnly={readOnly}
+				/>
+			</ContextPanelContent>
+		</ContextPanel>
+	),
+	order: 1,
+});
+```
+
+**Step 3: Wrap `links` tab content**
+
+Replace:
+```tsx
+registerTab({
+   id: "links",
+   icon: Link2,
+   label: "Links do Cluster",
+   content: <InternalLinksSidebar contentId={contentId} />,
+   order: 2,
+});
+```
+
+With:
+```tsx
+registerTab({
+	id: "links",
+	icon: Link2,
+	label: "Links do Cluster",
+	content: (
+		<ContextPanel>
+			<ContextPanelHeader>
+				<ContextPanelTitle>Links do Cluster</ContextPanelTitle>
+			</ContextPanelHeader>
+			<ContextPanelContent>
+				<InternalLinksSidebar contentId={contentId} />
+			</ContextPanelContent>
+		</ContextPanel>
+	),
+	order: 2,
+});
+```
+
+**Step 4: Verify TypeScript**
+
+```bash
+bun run typecheck 2>&1 | head -40
+```
+
+Expected: no errors
+
+**Step 5: Commit**
+
+```bash
+git add apps/web/src/features/editor/plate/ui/editor-context-panel-tabs.tsx
+git commit -m "feat(editor): migrate editor tabs to ContextPanel primitives"
+```
+
+---
+
+## Final verification
+
+```bash
+bun run typecheck 2>&1 | tail -5
+bun run check 2>&1 | tail -10
+```
+
+Expected: no TypeScript errors, no Biome lint errors.

--- a/docs/plans/2026-02-26-context-panel-routes-design.md
+++ b/docs/plans/2026-02-26-context-panel-routes-design.md
@@ -1,0 +1,174 @@
+# Context Panel Info — All Routes Design
+
+**Goal:** Fill the context panel info tab with relevant data on all main list and detail routes.
+
+**Scope:** List pages (B+) and detail pages (B). Chat, settings, billing, search, home, data-management sub-routes, and assets are excluded (read-only or incompatible with context panel actions).
+
+---
+
+## Pattern Reference
+
+All implementations use the primitives from `@packages/ui/components/context-panel` and helpers from `@/features/context-panel/context-panel-info`:
+
+```tsx
+import {
+  ContextPanel, ContextPanelContent,
+  ContextPanelHeader, ContextPanelTitle,
+} from "@packages/ui/components/context-panel";
+import {
+  ContextPanelAction, ContextPanelMeta, ContextPanelDivider,
+} from "@/features/context-panel/context-panel-info";
+import { useContextPanelInfo } from "@/features/context-panel/use-context-panel";
+```
+
+Use `useMemo` to stabilize JSX passed to `useContextPanelInfo` so the store only updates when relevant data changes.
+
+---
+
+## List Pages
+
+Four list pages get an "Ações" section with a single primary create action.
+
+### `writers/index.tsx`
+
+- **Action:** "Novo escritor"
+- **Trigger:** Call `createMutation.mutate({})` directly (mutation already exists in route)
+- **Icon:** `Plus`
+
+### `clusters/index.tsx`
+
+- **Action:** "Novo cluster"
+- **Trigger:** `navigate({ to: "/$slug/$teamSlug/clusters/new", params: { slug, teamSlug } })`
+- **Icon:** `Plus`
+
+### `experiments/index.tsx`
+
+- **Action:** "Novo experimento"
+- **Trigger:** `navigate({ to: "/$slug/$teamSlug/experiments/new", params: { slug, teamSlug } })`
+- **Icon:** `Plus`
+
+### `analytics/insights/index.tsx`
+
+- **Action:** "Novo insight"
+- **Trigger:** `navigate({ to: "/$slug/$teamSlug/analytics/insights/new", params: { slug, teamSlug } })`
+- **Icon:** `Plus`
+
+---
+
+## Detail Pages
+
+### `writers/$writerId.tsx`
+
+Data from `orpc.writer.getById`. Hook called in the route component.
+
+```
+[writer.name]               ← ContextPanelTitle
+──────────────────
+Conteúdos   {contentCount}  ← ContextPanelMeta
+Criado em   {createdAt}     ← ContextPanelMeta (dd/MM/yyyy)
+──────────────────
+🗑 Excluir escritor         ← ContextPanelAction (destructive) → handleDelete()
+```
+
+`useMemo` deps: `[writer?.name, writer?.contentCount, writer?.createdAt, handleDelete]`
+
+### `analytics/insights/$insightId.tsx`
+
+Data from `orpc.insights.getById`. Hook called in the route component.
+
+Type label mapping:
+- `trends` → "Tendências"
+- `funnels` → "Funis"
+- `retention` → "Retenção"
+
+Goal label mapping (used only internally, not shown in panel):
+
+```
+[insightName]                     ← ContextPanelTitle
+──────────────────
+Tipo        {typeLabel}           ← ContextPanelMeta
+Calculado   {lastComputedAt|"—"}  ← ContextPanelMeta (relative time or "—")
+──────────────────
+⧉ Duplicar                        ← ContextPanelAction → duplicateMutation
+↺ Atualizar resultados             ← ContextPanelAction → refreshResults
+🗑 Excluir insight                 ← ContextPanelAction (destructive) → deleteMutation
+```
+
+`useMemo` deps: `[insightName, insight?.type, insight?.lastComputedAt, ...]`
+
+### `clusters/$clusterId.tsx` — inside `ClusterBuilderEdit`
+
+`useContextPanelInfo` added inside `ClusterBuilderEdit` (where cluster data lives). Only edit mode — create mode shows nothing.
+
+Mode label mapping:
+- `seo` → "SEO"
+- `changelog` → "Changelog"
+- `series` → "Série"
+
+Status label mapping:
+- `draft` → "Rascunho"
+- `published` → "Publicado"
+
+```
+[pillarTitle]               ← ContextPanelTitle
+──────────────────
+Modo        {modeLabel}     ← ContextPanelMeta
+Status      {statusLabel}   ← ContextPanelMeta
+Satélites   {count}         ← ContextPanelMeta
+──────────────────
+🗑 Deletar cluster          ← ContextPanelAction (destructive) → handleDelete()
+```
+
+`useMemo` deps: `[pillarTitle, cluster?.status, cluster?.clusterConfig?.mode, satellites.length, handleDelete]`
+
+### `experiments/$experimentId.tsx` — inside `ExperimentBuilderEditContent`
+
+`useContextPanelInfo` added inside `ExperimentBuilderEditContent` (where experiment data and handlers live). Only edit mode — create mode shows nothing.
+
+targetType label mapping:
+- `content` → "Conteúdo"
+- `form` → "Formulário"
+- `cluster` → "Cluster"
+
+goal label mapping:
+- `conversion` → "Conversão"
+- `ctr` → "Taxa de clique"
+- `time_on_page` → "Tempo na página"
+- `form_submit` → "Envio de formulário"
+
+Actions shown conditionally (mirrors header logic):
+- "Iniciar" → when `canStart` (status draft|paused and variantCount >= 2)
+- "Pausar" → when `isRunning` (status running)
+- "Concluir" → when status running or paused
+- "Excluir" → always (destructive, disabled when running)
+
+```
+[experiment.name]           ← ContextPanelTitle
+──────────────────
+Status      {statusLabel}   ← ContextPanelMeta
+Tipo        {targetLabel}   ← ContextPanelMeta
+Meta        {goalLabel}     ← ContextPanelMeta
+Variantes   {variantCount}  ← ContextPanelMeta
+──────────────────
+▶ Iniciar                   ← conditional
+⏸ Pausar                    ← conditional
+✓ Concluir                  ← conditional
+🗑 Excluir experimento       ← always (destructive)
+```
+
+`useMemo` deps: `[experiment.name, experiment.status, experiment.targetType, experiment.goal, variantCount, canStart, isRunning, ...]`
+
+---
+
+## Files to Touch
+
+| File | Change |
+|------|--------|
+| `routes/.../writers/index.tsx` | Add `useContextPanelInfo` |
+| `routes/.../clusters/index.tsx` | Add `useContextPanelInfo` |
+| `routes/.../experiments/index.tsx` | Add `useContextPanelInfo` |
+| `routes/.../analytics/insights/index.tsx` | Add `useContextPanelInfo` |
+| `routes/.../writers/$writerId.tsx` | Add `useContextPanelInfo` |
+| `routes/.../analytics/insights/$insightId.tsx` | Add `useContextPanelInfo` |
+| `features/clusters/ui/cluster-builder.tsx` | Add `useContextPanelInfo` inside `ClusterBuilderEdit` |
+| `features/experiments/ui/experiment-builder.tsx` | Add `useContextPanelInfo` inside `ExperimentBuilderEditContent` |

--- a/docs/plans/2026-02-26-layout-standardization.md
+++ b/docs/plans/2026-02-26-layout-standardization.md
@@ -1,0 +1,707 @@
+# Layout Standardization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Eliminate layout anti-patterns (duplicate effects, bad deps, stale refs) and standardize state management across ContextPanel, SubSidebar, MainSidebar, and SidebarManager.
+
+**Architecture:** Phase 1 fixes three isolated bugs; Phase 2 makes the sub-sidebar fully store-driven (no local useState for searchQuery); Phase 3 moves section activation from a pathname-watching useEffect in the layout parent to co-located hooks inside each analytics route component.
+
+**Tech Stack:** TanStack Store, TanStack Router, React, Radix/Shadcn Sidebar, TypeScript.
+
+**Issue reference:** #740
+
+---
+
+## Phase 1 — Quick Fixes
+
+### Task 1: Fix `useContextPanelInfo` dependency array
+
+**Files:**
+- Modify: `apps/web/src/features/context-panel/use-context-panel.ts:40-46`
+
+**Context:** `useContextPanelInfo` registers `content` (a ReactNode) into the context panel store. The dependency array is intentionally empty to avoid stale content but this is incorrect — if the caller re-renders with new content (e.g., after async data loads), the panel will show stale content.
+
+**Step 1: Remove biome-ignore and add content dep**
+
+Replace `use-context-panel.ts:40-46`:
+```typescript
+// BEFORE
+export const useContextPanelInfo = (content: React.ReactNode) => {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: content is intentionally stable on mount
+  useEffect(() => {
+    setInfoContent(content);
+    return () => clearInfoContent();
+  }, []);
+};
+
+// AFTER
+export const useContextPanelInfo = (content: React.ReactNode) => {
+  useEffect(() => {
+    setInfoContent(content);
+    return () => clearInfoContent();
+  }, [content]);
+};
+```
+
+**Step 2: Verify callers remain correct**
+
+Known callers (search with `grep -r "useContextPanelInfo" apps/web/src`):
+- `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/index.tsx` — static JSX, no problem
+- `apps/web/src/features/content/ui/content-list-section.tsx` — static JSX, no problem
+
+No changes needed to callers.
+
+**Step 3: Verify TypeScript**
+```bash
+bun run typecheck
+```
+Expected: no new errors.
+
+**Step 4: Commit**
+```bash
+git add apps/web/src/features/context-panel/use-context-panel.ts
+git commit -m "fix(context-panel): add content to useContextPanelInfo deps array"
+```
+
+---
+
+### Task 2: Remove ThemeSwitcher mounted pattern
+
+**Files:**
+- Modify: `apps/web/src/layout/dashboard/ui/theme-switcher.tsx`
+
+**Context:** The `mounted` pattern (`useState(false)` + `useEffect(() => setMounted(true), [])` + `if (!mounted) return null`) causes a visual flash on mount. This is a pure client-side Vite SPA — no SSR. `useTheme()` already reads `theme` from localStorage on first render via the `isBrowser` check in the ThemeProvider's `useState` initializer, so the theme is correct from the first render. The `mounted` guard is unnecessary.
+
+**Step 1: Remove mounted state, effect, and guard**
+
+In `theme-switcher.tsx`:
+- Remove: `const [mounted, setMounted] = useState(false);`
+- Remove: the `useEffect(() => { setMounted(true); }, []);`
+- Remove: `if (!mounted) { return null; }`
+- Remove `useEffect` from the import (keep `useCallback`)
+
+The file's import line changes from:
+```typescript
+import { useCallback, useEffect, useState } from "react";
+```
+to:
+```typescript
+import { useCallback } from "react";
+```
+
+**Step 2: Verify TypeScript**
+```bash
+bun run typecheck
+```
+
+**Step 3: Manual visual check**
+Run `bun dev`, navigate to the sidebar. The theme switcher should render immediately on mount without a flash.
+
+**Step 4: Commit**
+```bash
+git add apps/web/src/layout/dashboard/ui/theme-switcher.tsx
+git commit -m "fix(theme-switcher): remove unnecessary mounted guard pattern"
+```
+
+---
+
+### Task 3: Consolidate duplicate SidebarManager registration effects
+
+**Files:**
+- Modify: `packages/ui/src/components/sidebar.tsx:115-240`
+
+**Context:** Both `SidebarManagerShared` (lines 115–143) and `SidebarManagerIsolated` (lines 145–239) have two `useEffect`s that both call `manager.register(name, ...)`. The first effect uses refs for initial registration + cleanup. The second effect keeps the registration fresh when context changes but has no cleanup. The `manager` object itself must NOT go in deps because `manager` is recreated whenever any sidebar registers/unregisters, which would cause an infinite registration loop. We keep refs for the manager but drop the redundant second effect.
+
+**Step 1: Consolidate SidebarManagerShared (lines ~115–143)**
+
+Remove both effects and the unused `sidebarContextRef`. Keep `managerRef` for stable unregister.
+
+Replace the block:
+```typescript
+const sidebarContextRef = React.useRef(sidebarContext);
+const managerRef = React.useRef(manager);
+
+React.useLayoutEffect(() => {
+  sidebarContextRef.current = sidebarContext;
+  managerRef.current = manager;
+});
+
+React.useEffect(() => {
+  managerRef.current.register(name, sidebarContextRef.current);
+  return () => managerRef.current.unregister(name);
+}, [name]);
+
+React.useEffect(() => {
+  managerRef.current.register(name, sidebarContext);
+}, [name, sidebarContext]);
+```
+
+With:
+```typescript
+const managerRef = React.useRef(manager);
+
+React.useLayoutEffect(() => {
+  managerRef.current = manager;
+});
+
+React.useEffect(() => {
+  managerRef.current.register(name, sidebarContext);
+  return () => managerRef.current.unregister(name);
+}, [name, sidebarContext]);
+```
+
+**Step 2: Consolidate SidebarManagerIsolated (lines ~213–227)**
+
+Replace:
+```typescript
+const managerRef = React.useRef(manager);
+const contextRef = React.useRef(contextValue);
+React.useLayoutEffect(() => {
+  managerRef.current = manager;
+  contextRef.current = contextValue;
+});
+
+React.useEffect(() => {
+  managerRef.current.register(name, contextRef.current);
+  return () => managerRef.current.unregister(name);
+}, [name]);
+
+React.useEffect(() => {
+  managerRef.current.register(name, contextValue);
+}, [name, contextValue]);
+```
+
+With:
+```typescript
+const managerRef = React.useRef(manager);
+
+React.useLayoutEffect(() => {
+  managerRef.current = manager;
+});
+
+React.useEffect(() => {
+  managerRef.current.register(name, contextValue);
+  return () => managerRef.current.unregister(name);
+}, [name, contextValue]);
+```
+
+**Step 3: Verify TypeScript**
+```bash
+bun run typecheck
+```
+
+**Step 4: Manual verification**
+Run `bun dev`. Navigate around the dashboard — the main sidebar, sub-panel, and context panel should all render and respond normally. No console errors.
+
+**Step 5: Commit**
+```bash
+git add packages/ui/src/components/sidebar.tsx
+git commit -m "fix(sidebar): consolidate duplicate SidebarManager registration effects"
+```
+
+---
+
+## Phase 2 — Sub-Sidebar Store-Driven
+
+### Task 4: Add `searchQuery` to sidebarNavStore
+
+**Files:**
+- Modify: `apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts`
+
+**Context:** Currently `searchQuery` lives in `useState` inside `SubPanelSidebar`. It gets reset via a `useEffect` when `activeSection` changes. Moving it to the store eliminates both the local state and the useEffect reset.
+
+**Step 1: Update the store interface and initial state**
+
+```typescript
+// BEFORE
+interface SidebarNavState {
+  activeSection: SubSidebarSection | null;
+  pinnedItems: string[];
+}
+
+const initialState: SidebarNavState = {
+  activeSection: null,
+  pinnedItems: loadPinnedItems(),
+};
+
+// AFTER
+interface SidebarNavState {
+  activeSection: SubSidebarSection | null;
+  searchQuery: string;
+  pinnedItems: string[];
+}
+
+const initialState: SidebarNavState = {
+  activeSection: null,
+  searchQuery: "",
+  pinnedItems: loadPinnedItems(),
+};
+```
+
+**Step 2: Update `setActiveSection` to reset searchQuery**
+
+```typescript
+// BEFORE
+export function setActiveSection(section: SubSidebarSection | null) {
+  sidebarNavStore.setState((state) => ({
+    ...state,
+    activeSection: section,
+  }));
+}
+
+// AFTER
+export function setActiveSection(section: SubSidebarSection | null) {
+  sidebarNavStore.setState((state) => ({
+    ...state,
+    activeSection: section,
+    searchQuery: "",
+  }));
+}
+```
+
+**Step 3: Add `setSearchQuery` export**
+
+After `setActiveSection`:
+```typescript
+export function setSearchQuery(query: string) {
+  sidebarNavStore.setState((state) => ({
+    ...state,
+    searchQuery: query,
+  }));
+}
+```
+
+**Step 4: Return `searchQuery` and `setSearchQuery` from `useSidebarNav`**
+
+```typescript
+// BEFORE
+export function useSidebarNav() {
+  const state = useStore(sidebarNavStore);
+  return {
+    activeSection: state.activeSection,
+    pinnedItems: state.pinnedItems,
+  };
+}
+
+// AFTER
+export function useSidebarNav() {
+  const state = useStore(sidebarNavStore);
+  return {
+    activeSection: state.activeSection,
+    searchQuery: state.searchQuery,
+    pinnedItems: state.pinnedItems,
+    setSearchQuery,
+  };
+}
+```
+
+**Step 5: Verify TypeScript**
+```bash
+bun run typecheck
+```
+
+**Step 6: Commit**
+```bash
+git add apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
+git commit -m "feat(sidebar-nav): add searchQuery to store, reset on section change"
+```
+
+---
+
+### Task 5: Make SubPanelSidebar fully store-driven
+
+**Files:**
+- Modify: `apps/web/src/layout/dashboard/ui/sidebar-sub-panel.tsx`
+
+**Context:** Two `useEffect`s remain in `SubPanelSidebar`:
+1. Resets `searchQuery` when `activeSection` changes — now handled by `setActiveSection`
+2. Calls `setOpen(false)` when `activeSection` becomes null — replaced by making `SidebarProvider` controlled
+
+**Step 1: Make `SidebarSubPanel` control open state from store**
+
+The `SidebarProvider` wrapping the sub-panel needs to be controlled via the store. When `activeSection` becomes null, the panel closes. When user closes (backdrop/X button), `setActiveSection(null)` is called.
+
+Replace the `SidebarSubPanel` component:
+```typescript
+// BEFORE
+export function SidebarSubPanel() {
+  const { activeSection } = useSidebarNav();
+  return (
+    <SidebarProvider className="min-h-0" defaultOpen={false}>
+      <SidebarManager name="sub-panel">
+        <SubPanelSidebar activeSection={activeSection} />
+      </SidebarManager>
+    </SidebarProvider>
+  );
+}
+
+// AFTER
+export function SidebarSubPanel() {
+  const { activeSection } = useSidebarNav();
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) setActiveSection(null);
+    },
+    [],
+  );
+
+  return (
+    <SidebarProvider
+      className="min-h-0"
+      onOpenChange={handleOpenChange}
+      open={activeSection !== null}
+    >
+      <SidebarManager name="sub-panel">
+        <SubPanelSidebar activeSection={activeSection} />
+      </SidebarManager>
+    </SidebarProvider>
+  );
+}
+```
+
+**Step 2: Remove `useState`, both `useEffect`s, and wire searchQuery from store**
+
+Replace the `SubPanelSidebar` component:
+```typescript
+// BEFORE
+function SubPanelSidebar({
+  activeSection,
+}: {
+  activeSection: SubSidebarSection | null;
+}) {
+  const { open, setOpen } = useSidebar();
+  const manager = useSidebarManager();
+  const mainSidebar = manager.use("main");
+  const panelLeft =
+    mainSidebar?.state === "collapsed"
+      ? "calc(var(--sidebar-width-icon) - 1px)"
+      : "calc(var(--sidebar-width) - 1px)";
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const handleItemClick = useCallback(() => {
+    setOpen(false);
+    setActiveSection(null);
+  }, [setOpen]);
+
+  // Reset search when section changes
+  useEffect(() => {
+    setSearchQuery("");
+  }, [activeSection]);
+
+  // Close when no active section
+  useEffect(() => {
+    if (!activeSection && open) {
+      setOpen(false);
+    }
+  }, [activeSection, open, setOpen]);
+
+  if (!open || !activeSection) return null;
+  // ...
+}
+
+// AFTER
+function SubPanelSidebar({
+  activeSection,
+}: {
+  activeSection: SubSidebarSection | null;
+}) {
+  const { open } = useSidebar();
+  const { searchQuery, setSearchQuery } = useSidebarNav();
+  const manager = useSidebarManager();
+  const mainSidebar = manager.use("main");
+  const panelLeft =
+    mainSidebar?.state === "collapsed"
+      ? "calc(var(--sidebar-width-icon) - 1px)"
+      : "calc(var(--sidebar-width) - 1px)";
+
+  const handleItemClick = useCallback(() => {
+    setActiveSection(null);
+  }, []);
+
+  if (!open || !activeSection) return null;
+  // ... (rest of JSX unchanged, use searchQuery/setSearchQuery from store)
+}
+```
+
+**Step 3: Update Input's onChange to use `setSearchQuery` from store**
+
+```typescript
+// BEFORE
+onChange={(e) => setSearchQuery(e.target.value)}
+
+// AFTER
+onChange={(e) => setSearchQuery(e.target.value)}
+// (same call, but now setSearchQuery comes from useSidebarNav() not useState)
+```
+
+**Step 4: Update imports** — remove `useEffect`, `useState` from React imports. Keep `useCallback`.
+
+**Step 5: Verify TypeScript**
+```bash
+bun run typecheck
+```
+
+**Step 6: Manual verification**
+- Open a dashboards sub-panel. Search for something. Navigate to insights section. Search box should be cleared.
+- Close via backdrop/X. Panel should close and section should deactivate.
+- No console errors.
+
+**Step 7: Commit**
+```bash
+git add apps/web/src/layout/dashboard/ui/sidebar-sub-panel.tsx
+git commit -m "refactor(sub-panel): make SubPanelSidebar fully store-driven, remove useEffects"
+```
+
+---
+
+## Phase 3 — Route-Based Section Sync
+
+### Task 6: Add `useSidebarSection` hook to use-sidebar-nav
+
+**Files:**
+- Modify: `apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts`
+
+**Context:** We need a hook that sets the active section when a component mounts and clears it when the component unmounts (navigates away). This moves section activation from the dashboard-layout's pathname-watching `useEffect` into each analytics route.
+
+**Step 1: Add the hook**
+
+Add after the existing hooks in `use-sidebar-nav.ts`:
+```typescript
+export function useSidebarSection(section: SubSidebarSection) {
+  useEffect(() => {
+    setActiveSection(section);
+    return () => setActiveSection(null);
+  }, [section]);
+}
+```
+
+**Note:** This requires adding `useEffect` import from `"react"` to the file (currently only `useStore` is imported from `@tanstack/react-store`).
+
+```typescript
+// BEFORE
+import { Store, useStore } from "@tanstack/react-store";
+
+// AFTER
+import { Store, useStore } from "@tanstack/react-store";
+import { useEffect } from "react";
+```
+
+**Step 2: Verify TypeScript**
+```bash
+bun run typecheck
+```
+
+**Step 3: Commit**
+```bash
+git add apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
+git commit -m "feat(sidebar-nav): add useSidebarSection hook for route-level section activation"
+```
+
+---
+
+### Task 7: Activate sections in analytics route components
+
+**Files:**
+- Modify: `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/index.tsx`
+- Modify: `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/$dashboardId.tsx`
+- Modify: `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/index.tsx`
+- Modify: `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/new.tsx`
+- Modify: `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId.tsx`
+- Modify: `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management.tsx`
+
+**Context:** Add `useSidebarSection("dashboards" | "insights" | "data-management")` to each analytics route's page component. This replaces the pathname-checking useEffect in dashboard-layout.
+
+**Step 1: Add to dashboards routes**
+
+In `analytics/dashboards/index.tsx`, in `DashboardsPage` function body (first line):
+```typescript
+import { useSidebarSection } from "@/layout/dashboard/hooks/use-sidebar-nav";
+
+function DashboardsPage() {
+  useSidebarSection("dashboards");
+  // ... rest unchanged
+}
+```
+
+In `analytics/dashboards/$dashboardId.tsx`, find the page component function, add:
+```typescript
+import { useSidebarSection } from "@/layout/dashboard/hooks/use-sidebar-nav";
+
+function DashboardViewPage() {
+  useSidebarSection("dashboards");
+  // ... rest unchanged
+}
+```
+
+**Step 2: Add to insights routes**
+
+In `analytics/insights/index.tsx`, in `InsightsListPage`:
+```typescript
+import { useSidebarSection } from "@/layout/dashboard/hooks/use-sidebar-nav";
+
+function InsightsListPage() {
+  useSidebarSection("insights");
+  // ... rest unchanged
+}
+```
+
+In `analytics/insights/new.tsx`, in `NewInsightPage`:
+```typescript
+import { useSidebarSection } from "@/layout/dashboard/hooks/use-sidebar-nav";
+
+function NewInsightPage() {
+  useSidebarSection("insights");
+  // ... rest unchanged
+}
+```
+
+In `analytics/insights/$insightId.tsx`, in `EditInsightPage`:
+```typescript
+import { useSidebarSection } from "@/layout/dashboard/hooks/use-sidebar-nav";
+
+function EditInsightPage() {
+  useSidebarSection("insights");
+  // ... rest unchanged
+}
+```
+
+**Step 3: Add to data-management layout route**
+
+In `analytics/data-management.tsx`, the layout component `DataManagementLayoutRoute`:
+```typescript
+import { useSidebarSection } from "@/layout/dashboard/hooks/use-sidebar-nav";
+
+function DataManagementLayoutRoute() {
+  useSidebarSection("data-management");
+  return (
+    <DataManagementLayout>
+      <Outlet />
+    </DataManagementLayout>
+  );
+}
+```
+
+This covers all data-management sub-routes automatically since it's a layout.
+
+**Step 4: Verify TypeScript**
+```bash
+bun run typecheck
+```
+
+**Step 5: Commit**
+```bash
+git add apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/
+git commit -m "feat(routes): activate sidebar sections via useSidebarSection in analytics routes"
+```
+
+---
+
+### Task 8: Remove pathname useEffect from dashboard-layout
+
+**Files:**
+- Modify: `apps/web/src/layout/dashboard/ui/dashboard-layout.tsx`
+
+**Context:** Now that each analytics route activates its own section via `useSidebarSection`, the pathname-watching `useEffect` in `dashboard-layout.tsx:132-142` is redundant and should be removed. Also remove the `pathname` and `setActiveSection` imports if no longer needed.
+
+**Step 1: Remove the useEffect**
+
+Remove from `dashboard-layout.tsx`:
+```typescript
+// DELETE THESE LINES (132-142)
+useEffect(() => {
+  if (pathname.includes("/analytics/dashboards")) {
+    setActiveSection("dashboards");
+  } else if (pathname.includes("/analytics/insights")) {
+    setActiveSection("insights");
+  } else if (pathname.includes("/analytics/data-management")) {
+    setActiveSection("data-management");
+  } else {
+    setActiveSection(null);
+  }
+}, [pathname]);
+```
+
+**Step 2: Remove unused imports**
+
+If `setActiveSection` is no longer used in `dashboard-layout.tsx`:
+```typescript
+// Remove from import:
+import { setActiveSection } from "../hooks/use-sidebar-nav";
+```
+
+Keep `useLocation` if still used (check: `pathname` is used for `isSettingsPage`, `isEditorPage`, `isChatPage`). Keep `useLocation`.
+
+**Step 3: Verify TypeScript and no unused variables**
+```bash
+bun run typecheck
+bun run check
+```
+
+**Step 4: Manual verification**
+- Navigate to `/analytics/dashboards` — sub-panel should open with dashboards section
+- Navigate to `/analytics/insights` — sub-panel should switch to insights
+- Navigate to `/analytics/data-management/event-definitions` — sub-panel should show data-management
+- Navigate to `/content` — sub-panel should close (section becomes null)
+
+**Step 5: Commit**
+```bash
+git add apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
+git commit -m "refactor(layout): remove pathname-based section sync useEffect"
+```
+
+---
+
+## Phase 4 — Internal Sidebar Review
+
+### Task 9: Verify InternalLinksSidebar integration
+
+**Files:**
+- Review: `apps/web/src/features/editor/plate/ui/internal-links-sidebar.tsx`
+
+**Context:** The issue flags this component for review after the `useContextPanelInfo` dep fix. `InternalLinksSidebar` itself does NOT call `useContextPanelInfo` — it's a pure display component. The parent that registers it as a context panel tab is what matters.
+
+**Step 1: Find how InternalLinksSidebar is registered as a tab**
+```bash
+grep -r "InternalLinksSidebar\|registerTab\|internal-links" apps/web/src --include="*.tsx" -l
+```
+
+**Step 2: Verify the registering component**
+
+If a component calls `registerTab` with `<InternalLinksSidebar />` as content, verify it's correct after the Phase 1 fix. No changes expected — `registerTab` is called imperatively, not via `useContextPanelInfo`.
+
+**Step 3: Confirm no issues**
+
+Run the app and open an editor page. Verify the internal links sidebar tab appears in the context panel and works correctly.
+
+**Step 4: Commit if any fix needed, otherwise no commit.**
+
+---
+
+## Final Verification
+
+**Step 1: Run full typecheck**
+```bash
+bun run typecheck
+```
+
+**Step 2: Run linter**
+```bash
+bun run check
+```
+
+**Step 3: Run tests**
+```bash
+bun run test
+```
+
+**Step 4: Smoke test in dev**
+```bash
+bun dev
+```
+Navigate through: content list → dashboards → dashboard detail → insights → new insight → data management → back to content. Verify:
+- Sub-panel opens/closes correctly for analytics sections
+- Search resets when switching sections
+- No console errors
+- Theme switcher renders without flash
+- Sidebar manager works (expand/collapse main sidebar while sub-panel is open)

--- a/docs/plans/2026-02-26-memory-2.md
+++ b/docs/plans/2026-02-26-memory-2.md
@@ -1,0 +1,548 @@
+# Memory 2.0 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement Working Memory, Observational Memory, and Semantic Recall for the Mastra agent system, wiring persistent storage to all content agents and enabling per-writer profile memory.
+
+**Architecture:**
+- Two shared `Memory` instances extracted to `packages/agents/src/mastra/memory/index.ts`: `platformMemory` (for chat/platform sessions, userId-scoped) and `contentMemory` (for content editing sessions, writerId-scoped, with full feature set).
+- All agent-local anonymous `Memory(...)` instances are replaced with these shared instances.
+- `mastraStorage` (PostgresStore) moves from `mastra/index.ts` to `memory/index.ts` so it can be referenced by Memory instances at module init time, then re-imported into the Mastra instance.
+- The `aiCommandStream` and `executeUnifiedAgent` oRPC handlers are updated to pass `memory: { thread: contentId, resource: writerId ?? userId }` when invoking the platformRouterAgent.
+
+**Tech Stack:** `@mastra/memory`, `@mastra/pg` (PostgresStore + PgVector), existing `pgVectorStore` and `embeddingModel` from `utils.ts`, existing `serverEnv.PG_VECTOR_URL`.
+
+---
+
+## Context: Current State
+
+- Each agent defines its own anonymous `new Memory({ options: { lastMessages: N, generateTitle: {...} } })` — no `storage`, no `vector`, no working memory.
+- Mastra's global `storage: mastraStorage` in `index.ts` is injected into agent Memory at Mastra init time. Memory **is** persisted now, but agents create their Memory instances before Mastra injects storage, so the exact timing is Mastra-internal.
+- To be explicit and safe (and to add WM/observational/semantic features), we create Memory instances with `storage` set directly.
+- `chat.ts` router already reads threads via `mastra.getAgent("platformRouterAgent").getMemory()` — this must keep working.
+- `agent.ts` router calls agents WITHOUT a `memory: { thread, resource }` param — this means content edits aren't stored in any thread.
+
+## What We Are NOT Changing
+
+- `get-instructions-tool.ts` — keeps reading `writerInstructions` from requestContext (backward compat)
+- `chat.ts` router — already correct; uses `${teamId}:${userId}` as resourceId
+- `fimAgent` / `inlineEditAgent` — stateless, keep their own minimal Memory or none
+- `CustomRequestContext` type — no changes needed
+- The `writerId ?? userId` pattern for resource is safe (userId is always present)
+
+---
+
+## Task 1: Create Working Memory Templates
+
+**Files:**
+- Create: `packages/agents/src/mastra/memory/schemas.ts`
+
+### Step 1: Write the file
+
+```typescript
+// packages/agents/src/mastra/memory/schemas.ts
+
+/**
+ * Working Memory template for writer-scoped content sessions.
+ * Stored per writerId (resource scope). Updated automatically by the agent
+ * via Mastra's built-in working memory tool.
+ */
+export const WRITER_PROFILE_TEMPLATE = `# Writer Profile
+
+## Writing Preferences
+- Tone: (not set)
+- Target Audience: (not set)
+- Writing Style: (not set)
+- Primary Keywords: []
+
+## SEO Preferences
+- Internal Linking Preferences: (not set)
+- Preferred Heading Structure: (not set)
+
+## Recent Context
+- Topics discussed in recent sessions: []
+- Current content focus: (not set)
+- Active instructions summary: (not set)
+`;
+
+/**
+ * Working Memory template for user-scoped platform sessions.
+ * Stored per userId (resource scope).
+ */
+export const USER_PROFILE_TEMPLATE = `# User Profile
+
+## Preferences
+- Language: pt-BR
+- Notifications: enabled
+
+## Recent Activity
+- Recent topics: []
+- Current page context: (not set)
+`;
+```
+
+### Step 2: Commit
+
+```bash
+git add packages/agents/src/mastra/memory/schemas.ts
+git commit -m "feat(agents/memory): add working memory templates for writer and user profiles"
+```
+
+---
+
+## Task 2: Create Shared Memory Instances + Extract mastraStorage
+
+**Files:**
+- Create: `packages/agents/src/mastra/memory/index.ts`
+- Modify: `packages/agents/src/mastra/index.ts`
+
+### Step 1: Create `memory/index.ts`
+
+```typescript
+// packages/agents/src/mastra/memory/index.ts
+import { Memory } from "@mastra/memory";
+import { PostgresStore } from "@mastra/pg";
+import { env as serverEnv } from "@packages/environment/server";
+import { embeddingModel, pgVectorStore } from "../utils";
+import { USER_PROFILE_TEMPLATE, WRITER_PROFILE_TEMPLATE } from "./schemas";
+
+/**
+ * Shared PostgreSQL storage for all Mastra agents.
+ * Extracted here so Memory instances can reference it at module init time,
+ * before the Mastra instance is constructed.
+ */
+export const mastraStorage = new PostgresStore({
+   id: "mastra-storage",
+   connectionString: serverEnv.PG_VECTOR_URL,
+});
+
+/**
+ * Memory for content editing sessions.
+ * Thread = contentId, Resource = writerId (or userId as fallback).
+ *
+ * Features:
+ * - Persistent storage (PostgreSQL)
+ * - Working Memory: writer profile, tone, keywords (per writerId)
+ * - Observational Memory: auto-compresses long editing sessions
+ * - Semantic Recall: recalls relevant messages from the same content session
+ * - generateTitle: auto-titles threads by content being edited
+ */
+export const contentMemory = new Memory({
+   storage: mastraStorage,
+   vector: pgVectorStore,
+   embedder: embeddingModel,
+   options: {
+      lastMessages: 20,
+      semanticRecall: {
+         topK: 5,
+         messageRange: { before: 2, after: 1 },
+         scope: "thread",
+      },
+      workingMemory: {
+         enabled: true,
+         template: WRITER_PROFILE_TEMPLATE,
+         scope: "resource",
+      },
+      observationalMemory: {
+         enabled: true,
+         scope: "thread",
+         model: "openrouter/google/gemini-2.5-flash",
+         observation: {
+            messageTokens: 1500,
+            bufferTokens: 0.2,
+            bufferActivation: 0.75,
+         },
+      },
+      generateTitle: {
+         model: "openrouter/google/gemini-2.5-flash-lite",
+      },
+   },
+});
+
+/**
+ * Memory for platform/chat sessions (general AI assistant).
+ * Thread = chatThreadId (UUID), Resource = `${teamId}:${userId}`.
+ *
+ * Features:
+ * - Persistent storage (PostgreSQL)
+ * - Working Memory: user preferences per userId
+ * - generateTitle: auto-titles conversation threads
+ */
+export const platformMemory = new Memory({
+   storage: mastraStorage,
+   options: {
+      lastMessages: 20,
+      workingMemory: {
+         enabled: true,
+         template: USER_PROFILE_TEMPLATE,
+         scope: "resource",
+      },
+      generateTitle: {
+         model: "openrouter/google/gemini-2.5-flash-lite",
+      },
+   },
+});
+```
+
+### Step 2: Update `index.ts` — Import mastraStorage from memory
+
+In `packages/agents/src/mastra/index.ts`:
+
+**Remove** the `PostgresStore` import and the local `mastraStorage` declaration:
+```typescript
+// REMOVE these lines:
+import { PostgresStore } from "@mastra/pg";
+// ...
+const mastraStorage = new PostgresStore({
+   id: "mastra-storage",
+   connectionString: serverEnv.PG_VECTOR_URL,
+});
+```
+
+**Add** import from the memory module:
+```typescript
+import { mastraStorage } from "./memory/index";
+```
+
+The `storage: mastraStorage` line in `new Mastra({ ... })` stays unchanged.
+
+### Step 3: Typecheck
+
+```bash
+bun run typecheck
+```
+
+Expected: No errors (just moved the PostgresStore construction, same types).
+
+### Step 4: Commit
+
+```bash
+git add packages/agents/src/mastra/memory/index.ts packages/agents/src/mastra/index.ts
+git commit -m "feat(agents/memory): create shared contentMemory + platformMemory with storage, WM, observational, semantic recall"
+```
+
+---
+
+## Task 3: Wire platformRouterAgent to platformMemory
+
+**Files:**
+- Modify: `packages/agents/src/mastra/agents/platform-router-agent.ts`
+
+### Step 1: Replace local Memory instance
+
+**Remove:**
+```typescript
+import { Memory } from "@mastra/memory";
+// ...
+const memory = new Memory({
+   options: {
+      lastMessages: 30,
+      generateTitle: {
+         model: "openrouter/google/gemini-2.5-flash-lite",
+      },
+   },
+});
+```
+
+**Add:**
+```typescript
+import { platformMemory } from "../memory/index";
+```
+
+**Replace** `memory,` in the Agent constructor with `memory: platformMemory,`.
+
+### Step 2: Typecheck
+
+```bash
+bun run typecheck
+```
+
+### Step 3: Commit
+
+```bash
+git add packages/agents/src/mastra/agents/platform-router-agent.ts
+git commit -m "feat(agents): wire platform-router-agent to platformMemory"
+```
+
+---
+
+## Task 4: Wire contentAgent to contentMemory
+
+**Files:**
+- Modify: `packages/agents/src/mastra/agents/content-agent.ts`
+
+### Step 1: Replace local Memory instance
+
+Same pattern as Task 3:
+
+**Remove:**
+```typescript
+import { Memory } from "@mastra/memory";
+// ...
+const memory = new Memory({
+   options: {
+      lastMessages: 30,
+      generateTitle: {
+         model: "openrouter/google/gemini-2.5-flash-lite",
+      },
+   },
+});
+```
+
+**Add:**
+```typescript
+import { contentMemory } from "../memory/index";
+```
+
+**Replace** `memory,` with `memory: contentMemory,`.
+
+### Step 2: Typecheck
+
+```bash
+bun run typecheck
+```
+
+### Step 3: Commit
+
+```bash
+git add packages/agents/src/mastra/agents/content-agent.ts
+git commit -m "feat(agents): wire content-agent to contentMemory"
+```
+
+---
+
+## Task 5: Wire researchAgent to contentMemory
+
+**Files:**
+- Modify: `packages/agents/src/mastra/agents/research-agent.ts`
+
+### Step 1: Replace local Memory instance (same pattern as Task 4)
+
+**Remove** the `import { Memory } from "@mastra/memory"` and the `const memory = new Memory({...})` block.
+
+**Add:**
+```typescript
+import { contentMemory } from "../memory/index";
+```
+
+**Replace** `memory,` with `memory: contentMemory,` in the Agent constructor.
+
+### Step 2: Typecheck
+
+```bash
+bun run typecheck
+```
+
+### Step 3: Commit
+
+```bash
+git add packages/agents/src/mastra/agents/research-agent.ts
+git commit -m "feat(agents): wire research-agent to contentMemory"
+```
+
+---
+
+## Task 6: Wire writerAgent to contentMemory
+
+**Files:**
+- Modify: `packages/agents/src/mastra/agents/writer-agent.ts`
+
+### Step 1: Replace local Memory instance (same pattern)
+
+Read the file first to identify the exact `import { Memory }` and `const memory = new Memory({...})` lines.
+
+Remove both, add `import { contentMemory } from "../memory/index"`, replace `memory,` with `memory: contentMemory,`.
+
+### Step 2: Typecheck
+
+```bash
+bun run typecheck
+```
+
+### Step 3: Commit
+
+```bash
+git add packages/agents/src/mastra/agents/writer-agent.ts
+git commit -m "feat(agents): wire writer-agent to contentMemory"
+```
+
+---
+
+## Task 7: Wire seoAuditorAgent and reviewerAgent to contentMemory
+
+**Files:**
+- Modify: `packages/agents/src/mastra/agents/seo-auditor-agent.ts`
+- Modify: `packages/agents/src/mastra/agents/reviewer-agent.ts`
+
+### Step 1: Apply same pattern to both files
+
+For each file:
+1. Remove `import { Memory } from "@mastra/memory"` and `const memory = new Memory({...})`
+2. Add `import { contentMemory } from "../memory/index"`
+3. Replace `memory,` with `memory: contentMemory,`
+
+### Step 2: Typecheck
+
+```bash
+bun run typecheck
+```
+
+### Step 3: Commit
+
+```bash
+git add packages/agents/src/mastra/agents/seo-auditor-agent.ts packages/agents/src/mastra/agents/reviewer-agent.ts
+git commit -m "feat(agents): wire seo-auditor-agent and reviewer-agent to contentMemory"
+```
+
+---
+
+## Task 8: Update oRPC agent router to pass thread/resource to agent calls
+
+**Files:**
+- Modify: `apps/web/src/integrations/orpc/router/agent.ts`
+
+### Context
+
+Currently both `aiCommandStream` and `executeUnifiedAgent` call the agent WITHOUT a `memory` param:
+```typescript
+const result = await unifiedAgent.stream(
+   [{ role: "user", content: input.prompt }],
+   {
+      requestContext: requestContext as RequestContext<unknown>,
+   } as unknown as Parameters<typeof unifiedAgent.stream>[1],
+);
+```
+
+This means AI command interactions are NOT stored in any thread — they happen in a "ghost" context. We fix this by passing `memory: { thread, resource }`.
+
+### Step 1: Update `aiCommandStream`
+
+In the `aiCommandStream` handler, find where `unifiedAgent.stream(...)` is called.
+
+**Replace** the stream call options with:
+```typescript
+{
+   requestContext: requestContext as RequestContext<unknown>,
+   memory: {
+      thread: input.contentId ?? `cmd-${userId}`,
+      resource: input.writerId ?? userId,
+   },
+} as unknown as Parameters<typeof unifiedAgent.stream>[1],
+```
+
+**Rationale:**
+- `thread: input.contentId` — all AI commands for a content piece share one thread (conversation history persists across page refreshes)
+- `thread: \`cmd-${userId}\`` — fallback for commands without a content context (no persistence across sessions needed, but thread is still scoped to user)
+- `resource: input.writerId ?? userId` — writer profile (working memory) persists per writer
+
+### Step 2: Update `executeUnifiedAgent`
+
+Find where `agent.generate(...)` is called.
+
+**Replace:**
+```typescript
+const result = await agent.generate(prompt, {
+   requestContext: requestContext as RequestContext<unknown>,
+});
+```
+
+**With:**
+```typescript
+const result = await agent.generate(prompt, {
+   requestContext: requestContext as RequestContext<unknown>,
+   memory: {
+      thread: contentId,
+      resource: writerId ?? userId,
+   },
+} as unknown as Parameters<typeof agent.generate>[1]);
+```
+
+### Step 3: Typecheck
+
+```bash
+bun run typecheck
+```
+
+Expected: No errors — the `as unknown as` cast handles the type for now.
+
+### Step 4: Commit
+
+```bash
+git add apps/web/src/integrations/orpc/router/agent.ts
+git commit -m "feat(agent-router): pass memory thread/resource to agent calls for persistent content sessions"
+```
+
+---
+
+## Task 9: Final Verification
+
+### Step 1: Run typecheck
+
+```bash
+bun run typecheck
+```
+
+Expected: No errors.
+
+### Step 2: Run Biome lint check
+
+```bash
+bun run check
+```
+
+Fix any lint issues found (unused imports, etc.).
+
+### Step 3: Run tests (if any agent tests exist)
+
+```bash
+bun run test
+```
+
+### Step 4: Commit any lint fixes
+
+```bash
+git add -p  # stage only lint fixes
+git commit -m "chore: fix lint issues after memory wiring"
+```
+
+---
+
+## Verification Checklist
+
+After all tasks:
+
+- [ ] `packages/agents/src/mastra/memory/index.ts` exists with `mastraStorage`, `contentMemory`, `platformMemory`
+- [ ] `packages/agents/src/mastra/memory/schemas.ts` exists with `WRITER_PROFILE_TEMPLATE`, `USER_PROFILE_TEMPLATE`
+- [ ] `packages/agents/src/mastra/index.ts` no longer creates `mastraStorage` locally; imports it from `./memory/index`
+- [ ] All 6 content agents (platformRouter, content, research, writer, seoAuditor, reviewer) no longer have local `new Memory(...)` — they use imported shared instances
+- [ ] `fimAgent` and `inlineEditAgent` are untouched (they are stateless)
+- [ ] `agent.ts` router passes `memory: { thread, resource }` in both `aiCommandStream` and `executeUnifiedAgent`
+- [ ] `chat.ts` router is untouched (it already works correctly)
+- [ ] `bun run typecheck` passes
+- [ ] `bun run check` (Biome) passes
+
+---
+
+## Notes for Implementer
+
+**Circular import risk:** `memory/index.ts` imports from `../utils` (pgVectorStore, embeddingModel). `utils.ts` does NOT import from agents or memory. This is safe.
+
+**PostgresStore is shared:** Both contentMemory and platformMemory use the SAME `mastraStorage` instance. Mastra Memory handles table-level isolation internally (different table names per memory instance or scoping by thread/resource).
+
+**Working memory is auto-managed:** Agents automatically get a built-in `update_working_memory` tool from Mastra when `workingMemory: { enabled: true }`. No manual tool needed. The agent updates the WM template by calling this tool.
+
+**ObservationalMemory model:** Uses `openrouter/google/gemini-2.5-flash` — make sure this is available in the OpenRouter credentials. If not, fall back to `openrouter/google/gemini-2.5-flash-lite`.
+
+**Semantic Recall index:** Mastra Memory creates its own vector index (separate from the RAG content index at `content_metadata`/`content_chunks`). The index name is auto-generated. These will appear as new tables in the database.
+
+**Thread ID strategy:**
+- Chat sessions: UUID (created by `chat.ts` createThread)
+- Content editing: `contentId` (stable UUID per content piece)
+- One-off AI commands without contentId: `cmd-${userId}` (ephemeral per user)
+
+**Resource ID strategy:**
+- Chat sessions: `${teamId}:${userId}` (team-scoped user)
+- Content editing: `writerId` if available, else `userId`
+- This means writer working memory (tone, keywords, etc.) is scoped to the writerId — shared across all content pieces the same writer works on
+
+**Backward compatibility:** The `getInstructionsTool` keeps working unchanged — it reads from `requestContext.writerInstructions`. Working Memory ADDS to this; it doesn't replace it. Both sources will be active simultaneously.

--- a/packages/agents/src/mastra/agents/content-network-agent.ts
+++ b/packages/agents/src/mastra/agents/content-network-agent.ts
@@ -4,31 +4,33 @@ import { Memory } from "@mastra/memory";
 import type { InstructionMemoryItem } from "@packages/database/schemas/instruction-memory";
 import { DEFAULT_CONTENT_MODEL_ID } from "../../models";
 import {
-	buildLanguageInstruction,
-	compileInstructionMemories,
+   buildLanguageInstruction,
+   compileInstructionMemories,
 } from "../../utils";
 import { researchAgent } from "./research-agent";
-import { writerAgent } from "./writer-agent";
-import { seoAuditorAgent } from "./seo-auditor-agent";
 import { reviewerAgent } from "./reviewer-agent";
+import { seoAuditorAgent } from "./seo-auditor-agent";
+import { writerAgent } from "./writer-agent";
 
 const memory = new Memory({
-	options: {
-		lastMessages: 30,
-		generateTitle: {
-			model: "openrouter/google/gemini-2.5-flash-lite",
-		},
-	},
+   options: {
+      lastMessages: 30,
+      generateTitle: {
+         model: "openrouter/google/gemini-2.5-flash-lite",
+      },
+   },
 });
 
 const getRouterInstructions = (
-	language: string,
-	writerInstructions?: InstructionMemoryItem[],
+   language: string,
+   writerInstructions?: InstructionMemoryItem[],
 ): string => {
-	const compiledMemories = compileInstructionMemories(writerInstructions ?? []);
-	const languageInstruction = buildLanguageInstruction(language);
+   const compiledMemories = compileInstructionMemories(
+      writerInstructions ?? [],
+   );
+   const languageInstruction = buildLanguageInstruction(language);
 
-	return `
+   return `
 ${languageInstruction}
 
 ${compiledMemories}
@@ -108,36 +110,36 @@ Respond in the same language as the user request.
  * sub-agents available to the router, which delegates via the network loop.
  */
 export const contentNetworkAgent: Agent = new Agent({
-	id: "content-network-agent",
-	name: "Content Network Agent",
-	description:
-		"Orchestration agent that routes content tasks to specialized agents for research, writing, SEO auditing, and review.",
+   id: "content-network-agent",
+   name: "Content Network Agent",
+   description:
+      "Orchestration agent that routes content tasks to specialized agents for research, writing, SEO auditing, and review.",
 
-	model: ({ requestContext }) => {
-		const maybeModel = requestContext?.get("model");
-		return typeof maybeModel === "string" && maybeModel.length > 0
-			? maybeModel
-			: DEFAULT_CONTENT_MODEL_ID;
-	},
+   model: ({ requestContext }) => {
+      const maybeModel = requestContext?.get("model");
+      return typeof maybeModel === "string" && maybeModel.length > 0
+         ? maybeModel
+         : DEFAULT_CONTENT_MODEL_ID;
+   },
 
-	instructions: ({ requestContext }) => {
-		const writerInstructions = requestContext?.get("writerInstructions") as
-			| InstructionMemoryItem[]
-			| undefined;
-		const language = (requestContext?.get("language") as string) ?? "pt-BR";
-		return getRouterInstructions(language, writerInstructions);
-	},
+   instructions: ({ requestContext }) => {
+      const writerInstructions = requestContext?.get("writerInstructions") as
+         | InstructionMemoryItem[]
+         | undefined;
+      const language = (requestContext?.get("language") as string) ?? "pt-BR";
+      return getRouterInstructions(language, writerInstructions);
+   },
 
-	memory,
+   memory,
 
-	// Sub-agents available for network delegation
-	agents: {
-		"research-agent": researchAgent,
-		"writer-agent": writerAgent,
-		"seo-auditor-agent": seoAuditorAgent,
-		"reviewer-agent": reviewerAgent,
-	},
+   // Sub-agents available for network delegation
+   agents: {
+      "research-agent": researchAgent,
+      "writer-agent": writerAgent,
+      "seo-auditor-agent": seoAuditorAgent,
+      "reviewer-agent": reviewerAgent,
+   },
 
-	// Router has no direct tools — specialists handle tool usage
-	tools: {},
+   // Router has no direct tools — specialists handle tool usage
+   tools: {},
 });

--- a/packages/agents/src/mastra/agents/research-agent.ts
+++ b/packages/agents/src/mastra/agents/research-agent.ts
@@ -3,43 +3,45 @@ import { Memory } from "@mastra/memory";
 import type { InstructionMemoryItem } from "@packages/database/schemas/instruction-memory";
 import { DEFAULT_CONTENT_MODEL_ID } from "../../models";
 import {
-	buildLanguageInstruction,
-	compileInstructionMemories,
+   buildLanguageInstruction,
+   compileInstructionMemories,
 } from "../../utils";
-import { contentGapTool } from "../tools/research/content-gap-tool";
+import { dateTool } from "../tools/date-tool";
+import { editDescriptionTool } from "../tools/frontmatter/edit-description-tool";
+import { editKeywordsTool } from "../tools/frontmatter/edit-keywords-tool";
+import { editSlugTool } from "../tools/frontmatter/edit-slug-tool";
+import { editTitleTool } from "../tools/frontmatter/edit-title-tool";
+import { getInstructionsTool } from "../tools/memory/get-instructions-tool";
+import { graphSearchTool } from "../tools/rag/graph-search-tool";
+import { searchPreviousContentTool } from "../tools/rag/search-previous-content-tool";
 import { competitorContentTool } from "../tools/research/competitor-content-tool";
+import { contentGapTool } from "../tools/research/content-gap-tool";
 import { factFinderTool } from "../tools/research/fact-finder-tool";
 import { relatedKeywordsTool } from "../tools/research/related-keywords-tool";
 import { researchCompletenessTool } from "../tools/research/research-completeness-tool";
 import { serpAnalysisTool } from "../tools/research/serp-analysis-tool";
 import { webCrawlTool } from "../tools/research/web-crawl-tool";
 import { webSearchTool } from "../tools/research/web-search-tool";
-import { getInstructionsTool } from "../tools/memory/get-instructions-tool";
-import { graphSearchTool } from "../tools/rag/graph-search-tool";
-import { searchPreviousContentTool } from "../tools/rag/search-previous-content-tool";
-import { editTitleTool } from "../tools/frontmatter/edit-title-tool";
-import { editDescriptionTool } from "../tools/frontmatter/edit-description-tool";
-import { editKeywordsTool } from "../tools/frontmatter/edit-keywords-tool";
-import { editSlugTool } from "../tools/frontmatter/edit-slug-tool";
-import { dateTool } from "../tools/date-tool";
 
 const memory = new Memory({
-	options: {
-		lastMessages: 20,
-		generateTitle: {
-			model: "openrouter/google/gemini-2.5-flash-lite",
-		},
-	},
+   options: {
+      lastMessages: 20,
+      generateTitle: {
+         model: "openrouter/google/gemini-2.5-flash-lite",
+      },
+   },
 });
 
 const getInstructions = (
-	language: string,
-	writerInstructions?: InstructionMemoryItem[],
+   language: string,
+   writerInstructions?: InstructionMemoryItem[],
 ): string => {
-	const compiledMemories = compileInstructionMemories(writerInstructions ?? []);
-	const languageInstruction = buildLanguageInstruction(language);
+   const compiledMemories = compileInstructionMemories(
+      writerInstructions ?? [],
+   );
+   const languageInstruction = buildLanguageInstruction(language);
 
-	return `
+   return `
 ${languageInstruction}
 
 ${compiledMemories}
@@ -103,44 +105,44 @@ Respond in the same language as the user request.
 };
 
 export const researchAgent: Agent = new Agent({
-	id: "research-agent",
-	name: "Research & Planning Agent",
-	description:
-		"Specialized in content research, SERP analysis, competitor analysis, keyword research, content gaps, and content planning. Use this agent for: researching topics, planning content structure, analyzing competitors, finding keyword opportunities, and building research briefings.",
+   id: "research-agent",
+   name: "Research & Planning Agent",
+   description:
+      "Specialized in content research, SERP analysis, competitor analysis, keyword research, content gaps, and content planning. Use this agent for: researching topics, planning content structure, analyzing competitors, finding keyword opportunities, and building research briefings.",
 
-	model: ({ requestContext }) => {
-		const maybeModel = requestContext?.get("model");
-		return typeof maybeModel === "string" && maybeModel.length > 0
-			? maybeModel
-			: DEFAULT_CONTENT_MODEL_ID;
-	},
+   model: ({ requestContext }) => {
+      const maybeModel = requestContext?.get("model");
+      return typeof maybeModel === "string" && maybeModel.length > 0
+         ? maybeModel
+         : DEFAULT_CONTENT_MODEL_ID;
+   },
 
-	instructions: ({ requestContext }) => {
-		const writerInstructions = requestContext?.get("writerInstructions") as
-			| InstructionMemoryItem[]
-			| undefined;
-		const language = (requestContext?.get("language") as string) ?? "pt-BR";
-		return getInstructions(language, writerInstructions);
-	},
+   instructions: ({ requestContext }) => {
+      const writerInstructions = requestContext?.get("writerInstructions") as
+         | InstructionMemoryItem[]
+         | undefined;
+      const language = (requestContext?.get("language") as string) ?? "pt-BR";
+      return getInstructions(language, writerInstructions);
+   },
 
-	memory,
+   memory,
 
-	tools: {
-		getInstructionMemories: getInstructionsTool,
-		searchPreviousContent: searchPreviousContentTool,
-		graphSearch: graphSearchTool,
-		webSearch: webSearchTool,
-		serpAnalysis: serpAnalysisTool,
-		contentGap: contentGapTool,
-		competitorContent: competitorContentTool,
-		relatedKeywords: relatedKeywordsTool,
-		factFinder: factFinderTool,
-		webCrawl: webCrawlTool,
-		researchCompleteness: researchCompletenessTool,
-		editTitle: editTitleTool,
-		editDescription: editDescriptionTool,
-		editKeywords: editKeywordsTool,
-		editSlug: editSlugTool,
-		dateTool: dateTool,
-	},
+   tools: {
+      getInstructionMemories: getInstructionsTool,
+      searchPreviousContent: searchPreviousContentTool,
+      graphSearch: graphSearchTool,
+      webSearch: webSearchTool,
+      serpAnalysis: serpAnalysisTool,
+      contentGap: contentGapTool,
+      competitorContent: competitorContentTool,
+      relatedKeywords: relatedKeywordsTool,
+      factFinder: factFinderTool,
+      webCrawl: webCrawlTool,
+      researchCompleteness: researchCompletenessTool,
+      editTitle: editTitleTool,
+      editDescription: editDescriptionTool,
+      editKeywords: editKeywordsTool,
+      editSlug: editSlugTool,
+      dateTool: dateTool,
+   },
 });

--- a/packages/agents/src/mastra/agents/reviewer-agent.ts
+++ b/packages/agents/src/mastra/agents/reviewer-agent.ts
@@ -3,8 +3,8 @@ import { Memory } from "@mastra/memory";
 import type { InstructionMemoryItem } from "@packages/database/schemas/instruction-memory";
 import { DEFAULT_CONTENT_MODEL_ID } from "../../models";
 import {
-	buildLanguageInstruction,
-	compileInstructionMemories,
+   buildLanguageInstruction,
+   compileInstructionMemories,
 } from "../../utils";
 import { badPatternTool } from "../tools/analysis/bad-pattern-tool";
 import { citationTool } from "../tools/analysis/citation-tool";
@@ -13,28 +13,30 @@ import { duplicateContentTool } from "../tools/analysis/duplicate-content-tool";
 import { originalityTool } from "../tools/analysis/originality-tool";
 import { readabilityTool } from "../tools/analysis/readability-tool";
 import { toneAnalysisTool } from "../tools/analysis/tone-analysis-tool";
+import { dateTool } from "../tools/date-tool";
 import { addEditorCommentTool } from "../tools/editor/add-editor-comment-tool";
 import { proposeSuggestionTool } from "../tools/editor/propose-suggestion-tool";
 import { replaceTextTool } from "../tools/editor/replace-text-tool";
-import { dateTool } from "../tools/date-tool";
 
 const memory = new Memory({
-	options: {
-		lastMessages: 20,
-		generateTitle: {
-			model: "openrouter/google/gemini-2.5-flash-lite",
-		},
-	},
+   options: {
+      lastMessages: 20,
+      generateTitle: {
+         model: "openrouter/google/gemini-2.5-flash-lite",
+      },
+   },
 });
 
 const getInstructions = (
-	language: string,
-	writerInstructions?: InstructionMemoryItem[],
+   language: string,
+   writerInstructions?: InstructionMemoryItem[],
 ): string => {
-	const compiledMemories = compileInstructionMemories(writerInstructions ?? []);
-	const languageInstruction = buildLanguageInstruction(language);
+   const compiledMemories = compileInstructionMemories(
+      writerInstructions ?? [],
+   );
+   const languageInstruction = buildLanguageInstruction(language);
 
-	return `
+   return `
 ${languageInstruction}
 
 ${compiledMemories}
@@ -93,39 +95,39 @@ Respond in the same language as the user request.
 };
 
 export const reviewerAgent: Agent = new Agent({
-	id: "reviewer-agent",
-	name: "Content Reviewer Agent",
-	description:
-		"Specialized in content quality review, tone analysis, readability assessment, citation validation, originality checking, and structural feedback. Use this agent for: reviewing content quality, checking tone consistency, validating citations, detecting AI-sounding patterns, content feedback.",
+   id: "reviewer-agent",
+   name: "Content Reviewer Agent",
+   description:
+      "Specialized in content quality review, tone analysis, readability assessment, citation validation, originality checking, and structural feedback. Use this agent for: reviewing content quality, checking tone consistency, validating citations, detecting AI-sounding patterns, content feedback.",
 
-	model: ({ requestContext }) => {
-		const maybeModel = requestContext?.get("model");
-		return typeof maybeModel === "string" && maybeModel.length > 0
-			? maybeModel
-			: DEFAULT_CONTENT_MODEL_ID;
-	},
+   model: ({ requestContext }) => {
+      const maybeModel = requestContext?.get("model");
+      return typeof maybeModel === "string" && maybeModel.length > 0
+         ? maybeModel
+         : DEFAULT_CONTENT_MODEL_ID;
+   },
 
-	instructions: ({ requestContext }) => {
-		const writerInstructions = requestContext?.get("writerInstructions") as
-			| InstructionMemoryItem[]
-			| undefined;
-		const language = (requestContext?.get("language") as string) ?? "pt-BR";
-		return getInstructions(language, writerInstructions);
-	},
+   instructions: ({ requestContext }) => {
+      const writerInstructions = requestContext?.get("writerInstructions") as
+         | InstructionMemoryItem[]
+         | undefined;
+      const language = (requestContext?.get("language") as string) ?? "pt-BR";
+      return getInstructions(language, writerInstructions);
+   },
 
-	memory,
+   memory,
 
-	tools: {
-		contentStructure: contentStructureTool,
-		citation: citationTool,
-		originality: originalityTool,
-		toneAnalysis: toneAnalysisTool,
-		readability: readabilityTool,
-		badPatterns: badPatternTool,
-		duplicateContent: duplicateContentTool,
-		addEditorComment: addEditorCommentTool,
-		proposeSuggestion: proposeSuggestionTool,
-		replaceText: replaceTextTool,
-		dateTool: dateTool,
-	},
+   tools: {
+      contentStructure: contentStructureTool,
+      citation: citationTool,
+      originality: originalityTool,
+      toneAnalysis: toneAnalysisTool,
+      readability: readabilityTool,
+      badPatterns: badPatternTool,
+      duplicateContent: duplicateContentTool,
+      addEditorComment: addEditorCommentTool,
+      proposeSuggestion: proposeSuggestionTool,
+      replaceText: replaceTextTool,
+      dateTool: dateTool,
+   },
 });

--- a/packages/agents/src/mastra/agents/seo-auditor-agent.ts
+++ b/packages/agents/src/mastra/agents/seo-auditor-agent.ts
@@ -3,8 +3,8 @@ import { Memory } from "@mastra/memory";
 import type { InstructionMemoryItem } from "@packages/database/schemas/instruction-memory";
 import { DEFAULT_CONTENT_MODEL_ID } from "../../models";
 import {
-	buildLanguageInstruction,
-	compileInstructionMemories,
+   buildLanguageInstruction,
+   compileInstructionMemories,
 } from "../../utils";
 import { badPatternTool } from "../tools/analysis/bad-pattern-tool";
 import { citationTool } from "../tools/analysis/citation-tool";
@@ -19,37 +19,39 @@ import { readabilityTool } from "../tools/analysis/readability-tool";
 import { seoScoreTool } from "../tools/analysis/seo-score-tool";
 import { titleMetaTool } from "../tools/analysis/title-meta-tool";
 import { toneAnalysisTool } from "../tools/analysis/tone-analysis-tool";
-import { editTitleTool } from "../tools/frontmatter/edit-title-tool";
+import { dateTool } from "../tools/date-tool";
+import { addExternalLinksTool } from "../tools/editor/add-external-links-tool";
+import { addInternalLinksTool } from "../tools/editor/add-internal-links-tool";
+import { generateQuickAnswerTool } from "../tools/editor/generate-quick-answer-tool";
+import { improveReadabilityTool } from "../tools/editor/improve-readability-tool";
+import { injectKeywordsTool } from "../tools/editor/inject-keywords-tool";
+import { optimizeMetaTool } from "../tools/editor/optimize-meta-tool";
+import { optimizeTitleTool } from "../tools/editor/optimize-title-tool";
+import { suggestImagesTool } from "../tools/editor/suggest-images-tool";
 import { editDescriptionTool } from "../tools/frontmatter/edit-description-tool";
 import { editKeywordsTool } from "../tools/frontmatter/edit-keywords-tool";
 import { editSlugTool } from "../tools/frontmatter/edit-slug-tool";
-import { optimizeTitleTool } from "../tools/editor/optimize-title-tool";
-import { optimizeMetaTool } from "../tools/editor/optimize-meta-tool";
-import { injectKeywordsTool } from "../tools/editor/inject-keywords-tool";
-import { addInternalLinksTool } from "../tools/editor/add-internal-links-tool";
-import { addExternalLinksTool } from "../tools/editor/add-external-links-tool";
-import { improveReadabilityTool } from "../tools/editor/improve-readability-tool";
-import { generateQuickAnswerTool } from "../tools/editor/generate-quick-answer-tool";
-import { suggestImagesTool } from "../tools/editor/suggest-images-tool";
-import { dateTool } from "../tools/date-tool";
+import { editTitleTool } from "../tools/frontmatter/edit-title-tool";
 
 const memory = new Memory({
-	options: {
-		lastMessages: 20,
-		generateTitle: {
-			model: "openrouter/google/gemini-2.5-flash-lite",
-		},
-	},
+   options: {
+      lastMessages: 20,
+      generateTitle: {
+         model: "openrouter/google/gemini-2.5-flash-lite",
+      },
+   },
 });
 
 const getInstructions = (
-	language: string,
-	writerInstructions?: InstructionMemoryItem[],
+   language: string,
+   writerInstructions?: InstructionMemoryItem[],
 ): string => {
-	const compiledMemories = compileInstructionMemories(writerInstructions ?? []);
-	const languageInstruction = buildLanguageInstruction(language);
+   const compiledMemories = compileInstructionMemories(
+      writerInstructions ?? [],
+   );
+   const languageInstruction = buildLanguageInstruction(language);
 
-	return `
+   return `
 ${languageInstruction}
 
 ${compiledMemories}
@@ -106,54 +108,54 @@ Respond in the same language as the user request.
 };
 
 export const seoAuditorAgent: Agent = new Agent({
-	id: "seo-auditor-agent",
-	name: "SEO Auditor Agent",
-	description:
-		"Specialized in SEO analysis, scoring, keyword density, readability, title/meta optimization, link density, image SEO, duplicate content detection, and applying SEO improvements. Use this agent for: SEO audits, SEO scores, keyword optimization, meta description optimization, readability improvements.",
+   id: "seo-auditor-agent",
+   name: "SEO Auditor Agent",
+   description:
+      "Specialized in SEO analysis, scoring, keyword density, readability, title/meta optimization, link density, image SEO, duplicate content detection, and applying SEO improvements. Use this agent for: SEO audits, SEO scores, keyword optimization, meta description optimization, readability improvements.",
 
-	model: ({ requestContext }) => {
-		const maybeModel = requestContext?.get("model");
-		return typeof maybeModel === "string" && maybeModel.length > 0
-			? maybeModel
-			: DEFAULT_CONTENT_MODEL_ID;
-	},
+   model: ({ requestContext }) => {
+      const maybeModel = requestContext?.get("model");
+      return typeof maybeModel === "string" && maybeModel.length > 0
+         ? maybeModel
+         : DEFAULT_CONTENT_MODEL_ID;
+   },
 
-	instructions: ({ requestContext }) => {
-		const writerInstructions = requestContext?.get("writerInstructions") as
-			| InstructionMemoryItem[]
-			| undefined;
-		const language = (requestContext?.get("language") as string) ?? "pt-BR";
-		return getInstructions(language, writerInstructions);
-	},
+   instructions: ({ requestContext }) => {
+      const writerInstructions = requestContext?.get("writerInstructions") as
+         | InstructionMemoryItem[]
+         | undefined;
+      const language = (requestContext?.get("language") as string) ?? "pt-BR";
+      return getInstructions(language, writerInstructions);
+   },
 
-	memory,
+   memory,
 
-	tools: {
-		seoScore: seoScoreTool,
-		readability: readabilityTool,
-		keywordDensity: keywordDensityTool,
-		contentStructure: contentStructureTool,
-		badPatterns: badPatternTool,
-		titleMeta: titleMetaTool,
-		quickAnswerAnalysis: quickAnswerAnalysisTool,
-		imageSeo: imageSeoTool,
-		linkDensity: linkDensityTool,
-		duplicateContent: duplicateContentTool,
-		toneAnalysis: toneAnalysisTool,
-		citation: citationTool,
-		originality: originalityTool,
-		editTitle: editTitleTool,
-		editDescription: editDescriptionTool,
-		editKeywords: editKeywordsTool,
-		editSlug: editSlugTool,
-		optimizeTitle: optimizeTitleTool,
-		optimizeMeta: optimizeMetaTool,
-		injectKeywords: injectKeywordsTool,
-		addInternalLinks: addInternalLinksTool,
-		addExternalLinks: addExternalLinksTool,
-		improveReadability: improveReadabilityTool,
-		generateQuickAnswer: generateQuickAnswerTool,
-		suggestImages: suggestImagesTool,
-		dateTool: dateTool,
-	},
+   tools: {
+      seoScore: seoScoreTool,
+      readability: readabilityTool,
+      keywordDensity: keywordDensityTool,
+      contentStructure: contentStructureTool,
+      badPatterns: badPatternTool,
+      titleMeta: titleMetaTool,
+      quickAnswerAnalysis: quickAnswerAnalysisTool,
+      imageSeo: imageSeoTool,
+      linkDensity: linkDensityTool,
+      duplicateContent: duplicateContentTool,
+      toneAnalysis: toneAnalysisTool,
+      citation: citationTool,
+      originality: originalityTool,
+      editTitle: editTitleTool,
+      editDescription: editDescriptionTool,
+      editKeywords: editKeywordsTool,
+      editSlug: editSlugTool,
+      optimizeTitle: optimizeTitleTool,
+      optimizeMeta: optimizeMetaTool,
+      injectKeywords: injectKeywordsTool,
+      addInternalLinks: addInternalLinksTool,
+      addExternalLinks: addExternalLinksTool,
+      improveReadability: improveReadabilityTool,
+      generateQuickAnswer: generateQuickAnswerTool,
+      suggestImages: suggestImagesTool,
+      dateTool: dateTool,
+   },
 });

--- a/packages/agents/src/mastra/agents/writer-agent.ts
+++ b/packages/agents/src/mastra/agents/writer-agent.ts
@@ -3,55 +3,57 @@ import { Memory } from "@mastra/memory";
 import type { InstructionMemoryItem } from "@packages/database/schemas/instruction-memory";
 import { DEFAULT_CONTENT_MODEL_ID } from "../../models";
 import {
-	buildLanguageInstruction,
-	compileInstructionMemories,
+   buildLanguageInstruction,
+   compileInstructionMemories,
 } from "../../utils";
-import { getInstructionsTool } from "../tools/memory/get-instructions-tool";
-import { graphSearchTool } from "../tools/rag/graph-search-tool";
-import { searchPreviousContentTool } from "../tools/rag/search-previous-content-tool";
-import { webSearchTool } from "../tools/research/web-search-tool";
-import { serpAnalysisTool } from "../tools/research/serp-analysis-tool";
-import { factFinderTool } from "../tools/research/fact-finder-tool";
-import { editTitleTool } from "../tools/frontmatter/edit-title-tool";
+import { dateTool } from "../tools/date-tool";
+import { addEditorCommentTool } from "../tools/editor/add-editor-comment-tool";
+import { addExternalLinksTool } from "../tools/editor/add-external-links-tool";
+import { addInternalLinksTool } from "../tools/editor/add-internal-links-tool";
+import { deleteTextTool } from "../tools/editor/delete-text-tool";
+import { formatTextTool } from "../tools/editor/format-text-tool";
+import { generateQuickAnswerTool } from "../tools/editor/generate-quick-answer-tool";
+import { improveReadabilityTool } from "../tools/editor/improve-readability-tool";
+import { injectKeywordsTool } from "../tools/editor/inject-keywords-tool";
+import { insertCodeBlockTool } from "../tools/editor/insert-code-block-tool";
+import { insertHeadingTool } from "../tools/editor/insert-heading-tool";
+import { insertImageTool } from "../tools/editor/insert-image-tool";
+import { insertListTool } from "../tools/editor/insert-list-tool";
+import { insertTableTool } from "../tools/editor/insert-table-tool";
+import { insertTextTool } from "../tools/editor/insert-text-tool";
+import { proposeSuggestionTool } from "../tools/editor/propose-suggestion-tool";
+import { replaceTextTool } from "../tools/editor/replace-text-tool";
+import { suggestImagesTool } from "../tools/editor/suggest-images-tool";
 import { editDescriptionTool } from "../tools/frontmatter/edit-description-tool";
 import { editKeywordsTool } from "../tools/frontmatter/edit-keywords-tool";
 import { editSlugTool } from "../tools/frontmatter/edit-slug-tool";
-import { addEditorCommentTool } from "../tools/editor/add-editor-comment-tool";
-import { insertTextTool } from "../tools/editor/insert-text-tool";
-import { replaceTextTool } from "../tools/editor/replace-text-tool";
-import { deleteTextTool } from "../tools/editor/delete-text-tool";
-import { formatTextTool } from "../tools/editor/format-text-tool";
-import { insertHeadingTool } from "../tools/editor/insert-heading-tool";
-import { insertListTool } from "../tools/editor/insert-list-tool";
-import { insertCodeBlockTool } from "../tools/editor/insert-code-block-tool";
-import { insertTableTool } from "../tools/editor/insert-table-tool";
-import { insertImageTool } from "../tools/editor/insert-image-tool";
-import { injectKeywordsTool } from "../tools/editor/inject-keywords-tool";
-import { addInternalLinksTool } from "../tools/editor/add-internal-links-tool";
-import { addExternalLinksTool } from "../tools/editor/add-external-links-tool";
-import { improveReadabilityTool } from "../tools/editor/improve-readability-tool";
-import { generateQuickAnswerTool } from "../tools/editor/generate-quick-answer-tool";
-import { suggestImagesTool } from "../tools/editor/suggest-images-tool";
-import { proposeSuggestionTool } from "../tools/editor/propose-suggestion-tool";
-import { dateTool } from "../tools/date-tool";
+import { editTitleTool } from "../tools/frontmatter/edit-title-tool";
+import { getInstructionsTool } from "../tools/memory/get-instructions-tool";
+import { graphSearchTool } from "../tools/rag/graph-search-tool";
+import { searchPreviousContentTool } from "../tools/rag/search-previous-content-tool";
+import { factFinderTool } from "../tools/research/fact-finder-tool";
+import { serpAnalysisTool } from "../tools/research/serp-analysis-tool";
+import { webSearchTool } from "../tools/research/web-search-tool";
 
 const memory = new Memory({
-	options: {
-		lastMessages: 30,
-		generateTitle: {
-			model: "openrouter/google/gemini-2.5-flash-lite",
-		},
-	},
+   options: {
+      lastMessages: 30,
+      generateTitle: {
+         model: "openrouter/google/gemini-2.5-flash-lite",
+      },
+   },
 });
 
 const getInstructions = (
-	language: string,
-	writerInstructions?: InstructionMemoryItem[],
+   language: string,
+   writerInstructions?: InstructionMemoryItem[],
 ): string => {
-	const compiledMemories = compileInstructionMemories(writerInstructions ?? []);
-	const languageInstruction = buildLanguageInstruction(language);
+   const compiledMemories = compileInstructionMemories(
+      writerInstructions ?? [],
+   );
+   const languageInstruction = buildLanguageInstruction(language);
 
-	return `
+   return `
 ${languageInstruction}
 
 ${compiledMemories}
@@ -116,56 +118,56 @@ Respond in the same language as the user request.
 };
 
 export const writerAgent: Agent = new Agent({
-	id: "writer-agent",
-	name: "Writer & Editor Agent",
-	description:
-		"Specialized in writing complete articles, editing content, formatting, inserting elements (headings, lists, tables, code blocks), and applying structured text edits. Use this agent for: writing full articles, editing existing content, reformatting, inserting new sections, applying inline edits.",
+   id: "writer-agent",
+   name: "Writer & Editor Agent",
+   description:
+      "Specialized in writing complete articles, editing content, formatting, inserting elements (headings, lists, tables, code blocks), and applying structured text edits. Use this agent for: writing full articles, editing existing content, reformatting, inserting new sections, applying inline edits.",
 
-	model: ({ requestContext }) => {
-		const maybeModel = requestContext?.get("model");
-		return typeof maybeModel === "string" && maybeModel.length > 0
-			? maybeModel
-			: DEFAULT_CONTENT_MODEL_ID;
-	},
+   model: ({ requestContext }) => {
+      const maybeModel = requestContext?.get("model");
+      return typeof maybeModel === "string" && maybeModel.length > 0
+         ? maybeModel
+         : DEFAULT_CONTENT_MODEL_ID;
+   },
 
-	instructions: ({ requestContext }) => {
-		const writerInstructions = requestContext?.get("writerInstructions") as
-			| InstructionMemoryItem[]
-			| undefined;
-		const language = (requestContext?.get("language") as string) ?? "pt-BR";
-		return getInstructions(language, writerInstructions);
-	},
+   instructions: ({ requestContext }) => {
+      const writerInstructions = requestContext?.get("writerInstructions") as
+         | InstructionMemoryItem[]
+         | undefined;
+      const language = (requestContext?.get("language") as string) ?? "pt-BR";
+      return getInstructions(language, writerInstructions);
+   },
 
-	memory,
+   memory,
 
-	tools: {
-		getInstructionMemories: getInstructionsTool,
-		searchPreviousContent: searchPreviousContentTool,
-		graphSearch: graphSearchTool,
-		webSearch: webSearchTool,
-		serpAnalysis: serpAnalysisTool,
-		factFinder: factFinderTool,
-		editTitle: editTitleTool,
-		editDescription: editDescriptionTool,
-		editKeywords: editKeywordsTool,
-		editSlug: editSlugTool,
-		addEditorComment: addEditorCommentTool,
-		insertText: insertTextTool,
-		proposeSuggestion: proposeSuggestionTool,
-		replaceText: replaceTextTool,
-		deleteText: deleteTextTool,
-		formatText: formatTextTool,
-		insertHeading: insertHeadingTool,
-		insertList: insertListTool,
-		insertCodeBlock: insertCodeBlockTool,
-		insertTable: insertTableTool,
-		insertImage: insertImageTool,
-		injectKeywords: injectKeywordsTool,
-		addInternalLinks: addInternalLinksTool,
-		addExternalLinks: addExternalLinksTool,
-		improveReadability: improveReadabilityTool,
-		generateQuickAnswer: generateQuickAnswerTool,
-		suggestImages: suggestImagesTool,
-		dateTool: dateTool,
-	},
+   tools: {
+      getInstructionMemories: getInstructionsTool,
+      searchPreviousContent: searchPreviousContentTool,
+      graphSearch: graphSearchTool,
+      webSearch: webSearchTool,
+      serpAnalysis: serpAnalysisTool,
+      factFinder: factFinderTool,
+      editTitle: editTitleTool,
+      editDescription: editDescriptionTool,
+      editKeywords: editKeywordsTool,
+      editSlug: editSlugTool,
+      addEditorComment: addEditorCommentTool,
+      insertText: insertTextTool,
+      proposeSuggestion: proposeSuggestionTool,
+      replaceText: replaceTextTool,
+      deleteText: deleteTextTool,
+      formatText: formatTextTool,
+      insertHeading: insertHeadingTool,
+      insertList: insertListTool,
+      insertCodeBlock: insertCodeBlockTool,
+      insertTable: insertTableTool,
+      insertImage: insertImageTool,
+      injectKeywords: injectKeywordsTool,
+      addInternalLinks: addInternalLinksTool,
+      addExternalLinks: addExternalLinksTool,
+      improveReadability: improveReadabilityTool,
+      generateQuickAnswer: generateQuickAnswerTool,
+      suggestImages: suggestImagesTool,
+      dateTool: dateTool,
+   },
 });

--- a/packages/agents/src/mastra/index.ts
+++ b/packages/agents/src/mastra/index.ts
@@ -9,10 +9,10 @@ import type { InstructionMemoryItem } from "@packages/database/schemas/instructi
 import { env as serverEnv } from "@packages/environment/server";
 import type { ModelId } from "../models";
 import { pgVectorStore } from "../utils";
-import { platformRouterAgent } from "./agents/platform-router-agent";
 import { contentAgent } from "./agents/content-agent";
 import { fimAgent } from "./agents/fim-agent";
 import { inlineEditAgent } from "./agents/inline-edit-agent";
+import { platformRouterAgent } from "./agents/platform-router-agent";
 import { researchAgent } from "./agents/research-agent";
 import { reviewerAgent } from "./agents/reviewer-agent";
 import { seoAuditorAgent } from "./agents/seo-auditor-agent";

--- a/packages/ui/src/components/context-panel.tsx
+++ b/packages/ui/src/components/context-panel.tsx
@@ -1,0 +1,92 @@
+import { cn } from "@packages/ui/lib/utils";
+import type React from "react";
+
+function ContextPanel({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn("flex h-full min-h-0 flex-col", className)}
+			data-slot="context-panel"
+			{...props}
+		/>
+	);
+}
+
+function ContextPanelHeader({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn(
+				"flex shrink-0 items-center gap-2 border-b px-3 py-2",
+				className,
+			)}
+			data-slot="context-panel-header"
+			{...props}
+		/>
+	);
+}
+
+function ContextPanelTitle({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn("flex-1 text-sm font-semibold", className)}
+			data-slot="context-panel-title"
+			{...props}
+		/>
+	);
+}
+
+function ContextPanelHeaderActions({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn("flex items-center gap-1", className)}
+			data-slot="context-panel-header-actions"
+			{...props}
+		/>
+	);
+}
+
+function ContextPanelContent({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn("flex min-h-0 flex-1 flex-col overflow-auto", className)}
+			data-slot="context-panel-content"
+			{...props}
+		/>
+	);
+}
+
+function ContextPanelFooter({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn("flex shrink-0 flex-col border-t p-2", className)}
+			data-slot="context-panel-footer"
+			{...props}
+		/>
+	);
+}
+
+export {
+	ContextPanel,
+	ContextPanelContent,
+	ContextPanelFooter,
+	ContextPanelHeader,
+	ContextPanelHeaderActions,
+	ContextPanelTitle,
+};

--- a/packages/ui/src/components/context-panel.tsx
+++ b/packages/ui/src/components/context-panel.tsx
@@ -4,7 +4,10 @@ import type React from "react";
 function ContextPanel({ className, ...props }: React.ComponentProps<"div">) {
    return (
       <div
-         className={cn("flex h-full min-h-0 flex-col", className)}
+         className={cn(
+            "px-2 pt-4 flex gap-4 h-full min-h-0 flex-col",
+            className,
+         )}
          data-slot="context-panel"
          {...props}
       />
@@ -18,7 +21,7 @@ function ContextPanelHeader({
    return (
       <div
          className={cn(
-            "flex shrink-0 bg-background items-center gap-2 rounded-xl px-2 py-2 mx-2 my-4",
+            "flex shrink-0 bg-background items-center gap-2 rounded-xl p-2  ",
             className,
          )}
          data-slot="context-panel-header"
@@ -59,7 +62,10 @@ function ContextPanelContent({
 }: React.ComponentProps<"div">) {
    return (
       <div
-         className={cn("flex min-h-0 flex-1 flex-col overflow-auto", className)}
+         className={cn(
+            "flex gap-4 min-h-0 flex-1 flex-col overflow-auto",
+            className,
+         )}
          data-slot="context-panel-content"
          {...props}
       />

--- a/packages/ui/src/components/context-panel.tsx
+++ b/packages/ui/src/components/context-panel.tsx
@@ -1,92 +1,89 @@
 import { cn } from "@packages/ui/lib/utils";
 import type React from "react";
 
-function ContextPanel({
-	className,
-	...props
-}: React.ComponentProps<"div">) {
-	return (
-		<div
-			className={cn("flex h-full min-h-0 flex-col", className)}
-			data-slot="context-panel"
-			{...props}
-		/>
-	);
+function ContextPanel({ className, ...props }: React.ComponentProps<"div">) {
+   return (
+      <div
+         className={cn("flex h-full min-h-0 flex-col", className)}
+         data-slot="context-panel"
+         {...props}
+      />
+   );
 }
 
 function ContextPanelHeader({
-	className,
-	...props
+   className,
+   ...props
 }: React.ComponentProps<"div">) {
-	return (
-		<div
-			className={cn(
-				"flex shrink-0 items-center gap-2 border-b px-3 py-2",
-				className,
-			)}
-			data-slot="context-panel-header"
-			{...props}
-		/>
-	);
+   return (
+      <div
+         className={cn(
+            "flex shrink-0 bg-background items-center gap-2 rounded-xl px-2 py-2 mx-2 my-4",
+            className,
+         )}
+         data-slot="context-panel-header"
+         {...props}
+      />
+   );
 }
 
 function ContextPanelTitle({
-	className,
-	...props
+   className,
+   ...props
 }: React.ComponentProps<"div">) {
-	return (
-		<div
-			className={cn("flex-1 text-sm font-semibold", className)}
-			data-slot="context-panel-title"
-			{...props}
-		/>
-	);
+   return (
+      <div
+         className={cn("flex-1 text-sm font-semibold", className)}
+         data-slot="context-panel-title"
+         {...props}
+      />
+   );
 }
 
 function ContextPanelHeaderActions({
-	className,
-	...props
+   className,
+   ...props
 }: React.ComponentProps<"div">) {
-	return (
-		<div
-			className={cn("flex items-center gap-1", className)}
-			data-slot="context-panel-header-actions"
-			{...props}
-		/>
-	);
+   return (
+      <div
+         className={cn("flex items-center gap-1", className)}
+         data-slot="context-panel-header-actions"
+         {...props}
+      />
+   );
 }
 
 function ContextPanelContent({
-	className,
-	...props
+   className,
+   ...props
 }: React.ComponentProps<"div">) {
-	return (
-		<div
-			className={cn("flex min-h-0 flex-1 flex-col overflow-auto", className)}
-			data-slot="context-panel-content"
-			{...props}
-		/>
-	);
+   return (
+      <div
+         className={cn("flex min-h-0 flex-1 flex-col overflow-auto", className)}
+         data-slot="context-panel-content"
+         {...props}
+      />
+   );
 }
 
 function ContextPanelFooter({
-	className,
-	...props
+   className,
+   ...props
 }: React.ComponentProps<"div">) {
-	return (
-		<div
-			className={cn("flex shrink-0 flex-col border-t p-2", className)}
-			data-slot="context-panel-footer"
-			{...props}
-		/>
-	);
+   return (
+      <div
+         className={cn("flex shrink-0 flex-col border-t p-2", className)}
+         data-slot="context-panel-footer"
+         {...props}
+      />
+   );
 }
 
 export {
-	ContextPanel,
-	ContextPanelContent,
-	ContextPanelFooter,
-	ContextPanelHeader,
-	ContextPanelHeaderActions,
-	ContextPanelTitle,
+   ContextPanel,
+   ContextPanelContent,
+   ContextPanelFooter,
+   ContextPanelHeader,
+   ContextPanelHeaderActions,
+   ContextPanelTitle,
 };

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -122,21 +122,15 @@ function SidebarManagerShared({
    const sidebarContext = useSidebar();
    const manager = useSidebarManager();
 
-   const sidebarContextRef = React.useRef(sidebarContext);
    const managerRef = React.useRef(manager);
 
    React.useLayoutEffect(() => {
-      sidebarContextRef.current = sidebarContext;
       managerRef.current = manager;
    });
 
    React.useEffect(() => {
-      managerRef.current.register(name, sidebarContextRef.current);
-      return () => managerRef.current.unregister(name);
-   }, [name]);
-
-   React.useEffect(() => {
       managerRef.current.register(name, sidebarContext);
+      return () => managerRef.current.unregister(name);
    }, [name, sidebarContext]);
 
    return <>{children}</>;
@@ -211,19 +205,14 @@ function SidebarManagerIsolated({
    );
 
    const managerRef = React.useRef(manager);
-   const contextRef = React.useRef(contextValue);
+
    React.useLayoutEffect(() => {
       managerRef.current = manager;
-      contextRef.current = contextValue;
    });
 
    React.useEffect(() => {
-      managerRef.current.register(name, contextRef.current);
-      return () => managerRef.current.unregister(name);
-   }, [name]);
-
-   React.useEffect(() => {
       managerRef.current.register(name, contextValue);
+      return () => managerRef.current.unregister(name);
    }, [name, contextValue]);
 
    return (
@@ -865,7 +854,7 @@ function SidebarMenuAction({
             "peer-data-[size=lg]/menu-button:top-2.5",
             "group-data-[collapsible=icon]:hidden",
             showOnHover &&
-            "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
+               "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
             className,
          )}
          data-sidebar="menu-action"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements comprehensive layout standardization across the application, focusing on eliminating anti-patterns and standardizing state management for ContextPanel, SubSidebar, MainSidebar, and SidebarManager components.

## Key Changes

**Layout Standardization:**
- Consolidated duplicate sidebar registration effects in `SidebarManagerShared` and `SidebarManagerIsolated` (removed redundant second effect without cleanup)
- Made SubPanelSidebar fully store-driven by moving `searchQuery` to TanStack Store, eliminating local `useState` and `useEffect` hooks
- Removed mounted guard pattern from ThemeSwitcher (replaced with `ClientOnly` wrapper for SSR safety)
- Moved section activation from pathname-watching useEffect in dashboard-layout to co-located `useSidebarSection` hooks in individual route components

**ContextPanel Primitives:**
- Added new composition primitives following Radix pattern: `ContextPanel`, `ContextPanelHeader`, `ContextPanelTitle`, `ContextPanelHeaderActions`, `ContextPanelContent`, `ContextPanelFooter`
- Migrated all callers from deprecated `ContextPanelSection` to new primitives (content-list-section, dashboards, forms, editor tabs, clusters, experiments)
- Added empty state handling for InfoContent and expand button for ChatContent

**Route-Level Section Management:**
- Added `useSidebarSection` hook with proper cleanup logic that conditionally clears section only if it matches the current active section
- Applied to all analytics routes (dashboards, insights, data-management) for automatic sidebar activation on mount

**Agent Changes:**
- Import reordering (alphabetization) and formatting changes (tabs to spaces) across writer-agent, research-agent, reviewer-agent, seo-auditor-agent, content-network-agent
- No functional changes to agent logic - Memory 2.0 plan was documented but NOT implemented in this PR

**Documentation:**
- Added comprehensive implementation plans for layout standardization, context panel primitives, and Memory 2.0 (future work)

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-executed refactoring with no critical issues
- Comprehensive refactoring that successfully eliminates layout anti-patterns and standardizes state management. All changes follow established patterns from the codebase, proper cleanup logic is implemented, and the migration is systematic. Agent changes are purely cosmetic (formatting/import ordering). No breaking changes or security concerns identified.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/ui/src/components/context-panel.tsx | New composition primitives for ContextPanel (Header, Title, Content, Footer, HeaderActions) - clean implementation following the Radix pattern |
| packages/ui/src/components/sidebar.tsx | Fixed duplicate registration effects in SidebarManagerShared and SidebarManagerIsolated - consolidated into single effect with cleanup |
| apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts | Added searchQuery to store, setSearchQuery function, and useSidebarSection hook for route-level section activation with proper cleanup |
| apps/web/src/layout/dashboard/ui/sidebar-sub-panel.tsx | Made SubPanelSidebar fully store-driven, removed useState and useEffect hooks, controlled open state from store via SidebarProvider |
| apps/web/src/layout/dashboard/ui/theme-switcher.tsx | Removed unnecessary mounted guard pattern, now wrapped in ClientOnly for SSR safety without flash on mount |
| apps/web/src/layout/dashboard/ui/dashboard-layout.tsx | Removed pathname-watching useEffect for section activation - now handled by useSidebarSection in individual route components |
| apps/web/src/features/context-panel/context-panel.tsx | Migrated to new ContextPanel primitives, added empty state for InfoContent, ChatContent now has expand button with navigation |
| apps/web/src/features/context-panel/context-panel-info.tsx | Removed deprecated ContextPanelSection component - replaced by new composition primitives throughout codebase |
| apps/web/src/features/editor/ui/editor-meta-panel.tsx | New component using ContextPanel primitives for editable content metadata with form validation and edit mode toggle |
| docs/plans/2026-02-26-layout-standardization.md | Implementation plan document for layout standardization - comprehensive guide for the changes made in this PR |
| docs/plans/2026-02-26-context-panel-primitives.md | Implementation plan for ContextPanel composition primitives - detailed migration guide followed in this PR |

</details>


</details>


<sub>Last reviewed commit: 68307e3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->